### PR TITLE
Add GitHub action to build and push a container to hub.docker.com

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,31 @@
+name: build
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Create additional environment variables
+        run: |
+          # get the tag and remove prefix
+          echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF//refs\/tags\//})
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Build and publish container
+        uses: docker/build-push-action@v2
+        with:
+          build_args: RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_REPOSITORY }}:latest
+            ${{ secrets.DOCKER_REPOSITORY }}:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,4 +1,4 @@
-name: build
+name: container
 
 on:
   push:

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -12,8 +12,9 @@ jobs:
       - uses: actions/checkout@master
       - name: Create additional environment variables
         run: |
-          # get the tag and remove prefix
-          echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF//refs\/tags\//})
+          # get the tag and remove 'v' prefix
+          TAG=${GITHUB_REF//refs\/tags\//}
+          echo "::set-env name=RELEASE_VERSION::${TAG//v/}"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage/
 examples/automation/create-account/variables.yml
 oc
 test/.ts
+tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # release version passed in on build, just default it temporarily
 ARG         RELEASE_VERSION=0.0.1
 
-FROM        node:13.10-alpine3.11
+FROM        node:12.18-alpine3.11
 RUN         npm install -g --production aws-organization-formation@${RELEASE_VERSION}
 WORKDIR     /workdir
 ENV         AWS_PROFILE=default

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# release version passed in on build, just default it temporarily
+ARG         RELEASE_VERSION=0.0.1
+
+FROM        node:13.10-alpine3.11
+RUN         npm install -g --production aws-organization-formation@${RELEASE_VERSION}
+WORKDIR     /workdir
+ENV         AWS_PROFILE=default
+ENTRYPOINT  [ "org-formation" ]

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ If you choose, you can run org-formation in a docker container:
 # Set the AWS_PROFILE environment variable and pass it to the container
 > AWS_PROFILE=example
 # Run the container
-> docker run --rm -it -v $HOME/.aws:/root/.aws:ro -v $PWD:/workdir -w /workdir -e AWS_PROFILE <TODO:CONFIRM_DOCKER_HUB_USER>/org-formation-cli
+> docker run --rm -it -v $HOME/.aws:/root/.aws:ro -v $PWD:/workdir -w /workdir -e AWS_PROFILE orgformation/org-formation-cli
 ```
 
 Optional: create an alias for the container:
 
 ```sh
-> alias org-formation='docker run --rm -it -v $HOME/.aws:/root/.aws:ro -v $PWD:/workdir -w /workdir -e AWS_PROFILE <TODO:CONFIRM_DOCKER_HUB_USER>/org-formation-cli'
+> alias org-formation='docker run --rm -it -v $HOME/.aws:/root/.aws:ro -v $PWD:/workdir -w /workdir -e AWS_PROFILE orgformation/org-formation-cli'
 ```
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ You can now execute the command line program `org-formation`. try:
 > org-formation --help
 ```
 
+### Docker
+
+If you choose, you can run org-formation in a docker container:
+
+```sh
+# Set the AWS_PROFILE environment variable and pass it to the container
+> AWS_PROFILE=example
+# Run the container
+> docker run --rm -it -v $HOME/.aws:/root/.aws:ro -v $PWD:/workdir -w /workdir -e AWS_PROFILE <TODO:CONFIRM_DOCKER_HUB_USER>/org-formation-cli
+```
+
+Optional: create an alias for the container:
+
+```sh
+> alias org-formation='docker run --rm -it -v $HOME/.aws:/root/.aws:ro -v $PWD:/workdir -w /workdir -e AWS_PROFILE <TODO:CONFIRM_DOCKER_HUB_USER>/org-formation-cli'
+```
+
 ## Getting started
 
 💡Need help getting started? [Get some on slack!](https://join.slack.com/t/org-formation/shared_invite/enQtOTA5NjM3Mzc4ODUwLTMxZjYxYzljZTE5YWUzODE2MTNmYjM5NTY5Nzc3MzljNjVlZGQ1ODEzZDgyMWVkMDg3Mzk1ZjQ1ZjM4MDhlOGM)


### PR DESCRIPTION
This PR adds a GitHub action to build and push a container to hub.docker.com in response to a tag being pushed to this repo.

# Initial Setup

## On hub.docker.com

- Create an account if you don't have one already, e.g. `username`.
- Create a token.
- Create a repo, e.g. `org-formation-cli`

## On GitHub

create the following secrets in this repo, `org-formation/org-formation-cli`:

- `DOCKER_USERNAME`, your username for hub.docker.com, e.g. `username`.
- `DOCKER_TOKEN`, the token associated with the username on hub.docker.com.
- `DOCKER_REPOSITORY`, the name of the user and repo on hub.docker.com, e.g. `username/org-formation-cli`

# Description

Once that's done, when you push a tag/RELEASE_VERSION to the repo, the GitHub action will do the following:

1. Login to hub.docker.com
2. Build a new container, passing the pushed tag/RELEASE_VERSION to the docker build, which is then used as the RELEASE_VERSION in the command: `npm install -g --production aws-organization-formation@${RELEASE_VERSION}`.
3. Push the container to hub.docker.com with the following tags:

- RELEASE_VERSION, e.g. `0.9.12`.
- `latest`, where `latest` will always have the same digest as the most recently pushed tag.

# Potential Issue

I marked this PR as draft as one potential issue I see with this is if your existing build process pushes to npm _after_ you tag this repo.  If you push to npm before you tag this repo, then it's o.k.  Let me know what your process is.