### PR TITLE
Amend !Ref to HostedZone with AWSAccount.Resources

### DIFF
--- a/examples/templates/subdomains.yml
+++ b/examples/templates/subdomains.yml
@@ -51,7 +51,7 @@ Resources:
     Properties:
       Name: !Sub '${resourcePrefix}-domains-hosted-zone-id'
       Type: String
-      Value: !Ref HostedZone
+      Value: !GetAtt AWSAccount.Resources.HostedZone
 
   HostedZoneNameParam:
     Type: AWS::SSM::Parameter


### PR DESCRIPTION
I was having a problem when running this example with multiple accounts with a subdomain. After investigation, I think we need to reference the hostedZone with `!GetAtt AWSAccount.Resources.HostedZone` in order to avoid this issue `validated failed. reason: Found multiple targets for reference to HostedZone`