### PR TITLE
Update github action for auto build on tag push

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -14,7 +14,9 @@ jobs:
         run: |
           # get the tag and remove 'v' prefix
           TAG=${GITHUB_REF//refs\/tags\//}
-          echo "::set-env name=RELEASE_VERSION::${TAG//v/}"
+          echo "RELEASE_VERSION=${TAG//v/}" >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
@@ -25,7 +27,8 @@ jobs:
       - name: Build and publish container
         uses: docker/build-push-action@v2
         with:
-          build_args: RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+          build-args: RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ secrets.DOCKER_REPOSITORY }}:latest


### PR DESCRIPTION
Why:

* Builds were failing because set-env among others was deprecated in favour of redirecting to a new file: `$GITHUB_ENV`
* Added support for multi architecture build, adding arm64 for those on Apple M1.