### PR TITLE
Support credential process and SSO from AWS CLI config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1899,39 +1899,29 @@
             }
         },
         "aws-sdk-mock": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-5.0.0.tgz",
-            "integrity": "sha512-8vSdiRj4dEu3z4kkmIqHhP5Wrfiucgu0PaZxuT3KDSpuQIHMtw/SsuRsREkDQRBdkMtBg4BuddLZA8pWOs6QmQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-5.1.0.tgz",
+            "integrity": "sha512-Wa5eCSo8HX0Snqb7FdBylaXMmfrAWoWZ+d7MFhiYsgHPvNvMEGjV945FF2qqE1U0Tolr1ALzik1fcwgaOhqUWQ==",
             "dev": true,
             "requires": {
-                "aws-sdk": "^2.596.0",
-                "sinon": "^8.0.1",
+                "aws-sdk": "^2.637.0",
+                "sinon": "^9.0.1",
                 "traverse": "^0.6.6"
             },
             "dependencies": {
                 "@sinonjs/commons": {
-                    "version": "1.7.1",
-                    "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
-                    "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+                    "version": "1.8.2",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
+                    "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
                     "dev": true,
                     "requires": {
                         "type-detect": "4.0.8"
                     }
                 },
-                "@sinonjs/formatio": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
-                    "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
-                    "dev": true,
-                    "requires": {
-                        "@sinonjs/commons": "^1",
-                        "@sinonjs/samsam": "^4.2.0"
-                    }
-                },
                 "@sinonjs/samsam": {
-                    "version": "4.2.2",
-                    "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.2.tgz",
-                    "integrity": "sha512-z9o4LZUzSD9Hl22zV38aXNykgFeVj8acqfFabCY6FY83n/6s/XwNJyYYldz6/9lBJanpno9h+oL6HTISkviweA==",
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+                    "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
                     "dev": true,
                     "requires": {
                         "@sinonjs/commons": "^1.6.0",
@@ -1939,73 +1929,42 @@
                         "type-detect": "^4.0.8"
                     }
                 },
-                "aws-sdk": {
-                    "version": "2.630.0",
-                    "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.630.0.tgz",
-                    "integrity": "sha512-7BDPUIqmMZfZf+KN2Z3RpGDYGkEucQORLM2EqXuE91ETW5ySvoNd771+EaE3OS+FUx3JejfcVk8Rr2ZFU38RjA==",
-                    "dev": true,
-                    "requires": {
-                        "buffer": "4.9.1",
-                        "events": "1.1.1",
-                        "ieee754": "1.1.13",
-                        "jmespath": "0.15.0",
-                        "querystring": "0.2.0",
-                        "sax": "1.2.1",
-                        "url": "0.10.3",
-                        "uuid": "3.3.2",
-                        "xml2js": "0.4.19"
-                    }
-                },
-                "ieee754": {
-                    "version": "1.1.13",
-                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-                    "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-                    "dev": true
-                },
-                "lolex": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
-                    "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
-                    "dev": true,
-                    "requires": {
-                        "@sinonjs/commons": "^1.7.0"
-                    }
-                },
                 "nise": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.1.tgz",
-                    "integrity": "sha512-fYcH9y0drBGSoi88kvhpbZEsenX58Yr+wOJ4/Mi1K4cy+iGP/a73gNoyNhu5E9QxPdgTlVChfIaAlnyOy/gHUA==",
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+                    "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
                     "dev": true,
                     "requires": {
                         "@sinonjs/commons": "^1.7.0",
-                        "@sinonjs/formatio": "^4.0.1",
+                        "@sinonjs/fake-timers": "^6.0.0",
                         "@sinonjs/text-encoding": "^0.7.1",
                         "just-extend": "^4.0.2",
-                        "lolex": "^5.0.1",
                         "path-to-regexp": "^1.7.0"
                     }
                 },
                 "sinon": {
-                    "version": "8.1.1",
-                    "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.1.1.tgz",
-                    "integrity": "sha512-E+tWr3acRdoe1nXbHMu86SSqA1WGM7Yw3jZRLvlCMnXwTHP8lgFFVn5BnKnF26uc5SfZ3D7pA9sN7S3Y2jG4Ew==",
+                    "version": "9.2.4",
+                    "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+                    "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
                     "dev": true,
                     "requires": {
-                        "@sinonjs/commons": "^1.7.0",
-                        "@sinonjs/formatio": "^4.0.1",
-                        "@sinonjs/samsam": "^4.2.2",
+                        "@sinonjs/commons": "^1.8.1",
+                        "@sinonjs/fake-timers": "^6.0.1",
+                        "@sinonjs/samsam": "^5.3.1",
                         "diff": "^4.0.2",
-                        "lolex": "^5.1.2",
-                        "nise": "^3.0.1",
+                        "nise": "^4.0.4",
                         "supports-color": "^7.1.0"
                     }
-                },
-                "uuid": {
-                    "version": "3.3.2",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-                    "dev": true
                 }
+            }
+        },
+        "aws-sdk-sso": {
+            "version": "github:eduardomourar/aws-sdk-sso#8b01fb1d75090e6325257b2d5049c0ab662d1cec",
+            "from": "github:eduardomourar/aws-sdk-sso#feature/support-typescript",
+            "requires": {
+                "aws-sdk": "^2.786.0",
+                "open": "^7.1.0",
+                "sha1": "^1.1.1"
             }
         },
         "aws-sign2": {
@@ -2277,17 +2236,6 @@
             "dev": true,
             "requires": {
                 "node-int64": "^0.4.0"
-            }
-        },
-        "buffer": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-            "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-            "dev": true,
-            "requires": {
-                "base64-js": "^1.0.2",
-                "ieee754": "^1.1.4",
-                "isarray": "^1.0.0"
             }
         },
         "buffer-crc32": {
@@ -4134,9 +4082,7 @@
         "is-docker": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
-            "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
-            "dev": true,
-            "optional": true
+            "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw=="
         },
         "is-extendable": {
             "version": "0.1.1",
@@ -4244,8 +4190,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
             "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dev": true,
-            "optional": true,
             "requires": {
                 "is-docker": "^2.0.0"
             }
@@ -7173,6 +7117,15 @@
                 "mimic-fn": "^2.1.0"
             }
         },
+        "open": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/open/-/open-7.4.1.tgz",
+            "integrity": "sha512-Pxv+fKRsd/Ozflgn2Gjev1HZveJJeKR6hKKmdaImJMuEZ6htAvCTbcMABJo+qevlAelTLCrEK3YTKZ9fVTcSPw==",
+            "requires": {
+                "is-docker": "^2.0.0",
+                "is-wsl": "^2.1.1"
+            }
+        },
         "optionator": {
             "version": "0.8.3",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -8017,6 +7970,15 @@
                         "is-extendable": "^0.1.0"
                     }
                 }
+            }
+        },
+        "sha1": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
+            "integrity": "sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=",
+            "requires": {
+                "charenc": ">= 0.0.1",
+                "crypt": ">= 0.0.1"
             }
         },
         "shebang-command": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/OlafConijn/AwsOrganizationFormation.git"
+    "url": "https://github.com/org-formation/org-formation-cli.git"
   },
   "author": "Olaf Conijn",
   "license": "MIT",
@@ -37,6 +37,7 @@
     "@types/rc": "^1.1.0",
     "archiver": "^3.1.1",
     "aws-sdk": "^2.786.0",
+    "aws-sdk-sso": "github:eduardomourar/aws-sdk-sso#feature/support-typescript",
     "commander": "^2.20.0",
     "ini": "^1.3.5",
     "js-yaml": "^4.0.0",
@@ -62,7 +63,7 @@
     "@typescript-eslint/eslint-plugin": "^2.19.0",
     "@typescript-eslint/parser": "^2.19.0",
     "@zerollup/ts-transform-paths": "^1.7.12",
-    "aws-sdk-mock": "^5.0.0",
+    "aws-sdk-mock": "^5.1.0",
     "eslint": "^6.8.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-prefer-arrow": "^1.1.7",

--- a/src/util/aws-util.ts
+++ b/src/util/aws-util.ts
@@ -1,8 +1,5 @@
-import { existsSync, readFileSync } from 'fs';
 import { CloudFormation, IAM, S3, STS, Support, CredentialProviderChain, Organizations } from 'aws-sdk';
 import { CredentialsOptions } from 'aws-sdk/lib/credentials';
-import { AssumeRoleRequest } from 'aws-sdk/clients/sts';
-import * as ini from 'ini';
 import AWS from 'aws-sdk';
 import { provider } from 'aws-sdk/lib/credentials/credential_provider_chain';
 import { ListExportsInput, UpdateStackInput, DescribeStacksOutput, CreateStackInput, ValidateTemplateInput } from 'aws-sdk/clients/cloudformation';
@@ -14,6 +11,7 @@ import { GlobalState } from './global-state';
 import { PasswordPolicyResource, Reference } from '~parser/model';
 import { ICfnBinding } from '~cfn-binder/cfn-binder';
 
+type CredentialProviderOptions = ConstructorParameters<typeof AWS.SharedIniFileCredentials>[0];
 
 export const DEFAULT_ROLE_FOR_ORG_ACCESS = { RoleName: 'OrganizationAccountAccessRole' };
 export const DEFAULT_ROLE_FOR_CROSS_ACCOUNT_ACCESS = { RoleName: 'OrganizationAccountAccessRole' };
@@ -41,22 +39,32 @@ export class AwsUtil {
 
     }
 
-    public static async InitializeWithProfile(profile?: string): Promise<void> {
+    public static async InitializeWithProfile(profile?: string): Promise<AWS.Credentials> {
 
         if (profile) {
-            await this.Initialize([
-                (): AWS.Credentials => new CustomMFACredentials(profile),
-                (): AWS.Credentials => new AWS.SharedIniFileCredentials({ profile }),
-            ]);
-        } else {
-            await this.Initialize(CredentialProviderChain.defaultProviders);
-        }
+            process.env.AWS_SDK_LOAD_CONFIG = '1';
+            const params: CredentialProviderOptions = { profile };
+            if (process.env.AWS_SHARED_CREDENTIALS_FILE) {
+              params.filename = process.env.AWS_SHARED_CREDENTIALS_FILE;
+            }
 
+            // Setup a MFA callback to ask the code from user
+            params.tokenCodeFn = async (mfaSerial: string, callback: any): Promise<void> => {
+              const token = await ConsoleUtil.Readline(`👋 Enter MFA code for ${mfaSerial}`);
+              callback(null, token);
+            };
+
+            return await this.Initialize([
+                (): AWS.Credentials => new AWS.SharedIniFileCredentials(params),
+                (): AWS.Credentials => new AWS.ProcessCredentials(params),
+            ]);
+        }
+        return await this.Initialize(CredentialProviderChain.defaultProviders);
     }
 
-    public static async Initialize(providers: provider[]): Promise<void> {
+    public static async Initialize(providers: provider[]): Promise<AWS.Credentials> {
         const chainProvider = new CredentialProviderChain(providers);
-        AWS.config.credentials = await chainProvider.resolvePromise();
+        return AWS.config.credentials = await chainProvider.resolvePromise();
     }
 
     public static SetMasterAccountId(masterAccountId: string): void {
@@ -349,68 +357,6 @@ export class CfnUtil {
         } while (retryStackIsBeingUpdated || retryAccountIsBeingInitialized);
         return describeStack;
     }
-}
-
-class CustomMFACredentials extends AWS.Credentials {
-    profile: string;
-
-    constructor(profile: string) {
-        super(undefined);
-        this.profile = profile;
-    }
-
-    refresh(callback: (err: AWS.AWSError) => void): void {
-        const that = this;
-        this.innerRefresh()
-            .then(creds => {
-                that.accessKeyId = creds.accessKeyId;
-                that.secretAccessKey = creds.secretAccessKey;
-                that.sessionToken = creds.sessionToken;
-                callback(undefined);
-            })
-            .catch(err => { callback(err); });
-    };
-
-    async innerRefresh(): Promise<CredentialsOptions> {
-        const profileName = this.profile ? this.profile : 'default';
-        const homeDir = require('os').homedir();
-        // todo: add support for windows?
-        if (!existsSync(homeDir + '/.aws/config')) {
-            return;
-        }
-        const awsconfig = readFileSync(homeDir + '/.aws/config').toString('utf8');
-        const contents = ini.parse(awsconfig);
-        const profileKey = contents['profile ' + profileName];
-        if (profileKey && profileKey.source_profile) {
-            const awssecrets = readFileSync(homeDir + '/.aws/credentials').toString('utf8');
-            const secrets = ini.parse(awssecrets);
-            const creds = secrets[profileKey.source_profile];
-            const credentialsForSts: CredentialsOptions = { accessKeyId: creds.aws_access_key_id, secretAccessKey: creds.aws_secret_access_key };
-            if (creds.aws_session_token !== undefined) {
-                credentialsForSts.sessionToken = creds.aws_session_token;
-            }
-            const sts = new STS({ credentials: credentialsForSts });
-
-            const assumeRoleReq: AssumeRoleRequest = {
-                RoleArn: profileKey.role_arn,
-                RoleSessionName: 'organization-build',
-            };
-
-            if (profileKey.mfa_serial !== undefined) {
-                const token = await ConsoleUtil.Readline(`👋 Enter MFA code for ${profileKey.mfa_serial}`);
-                assumeRoleReq.SerialNumber = profileKey.mfa_serial;
-                assumeRoleReq.TokenCode = token;
-            }
-
-            try {
-                const tokens = await sts.assumeRole(assumeRoleReq).promise();
-                return { accessKeyId: tokens.Credentials.AccessKeyId, secretAccessKey: tokens.Credentials.SecretAccessKey, sessionToken: tokens.Credentials.SessionToken };
-            } catch (err) {
-                throw new OrgFormationError(`unable to assume role, error: \n${err}`);
-            }
-        }
-    }
-
 }
 
 const sleep = (seconds: number): Promise<void> => {

--- a/test/unit-tests/util/aws-config-file
+++ b/test/unit-tests/util/aws-config-file
@@ -1,0 +1,18 @@
+[default]
+output = json
+region = us-east-1
+
+[profile mfa]
+source_profile = default
+role_arn = arn:aws:iam::123456789012:role/assumable
+mfa_serial = arn:aws:iam::123456789012:mfa/virtual
+
+[profile credential-process]
+credential_process = exec-credential-process credential-process
+
+[profile aws-sso]
+sso_start_url = https://11111111.awsapps.com/start
+sso_region = us-east-1
+sso_account_id = 123456789012
+sso_role_name = admin
+credential_process = exec-credential-process aws-sso

--- a/test/unit-tests/util/aws-config-file
+++ b/test/unit-tests/util/aws-config-file
@@ -15,4 +15,3 @@ sso_start_url = https://11111111.awsapps.com/start
 sso_region = us-east-1
 sso_account_id = 123456789012
 sso_role_name = admin
-credential_process = exec-credential-process aws-sso

--- a/test/unit-tests/util/aws-shared-credentials-file
+++ b/test/unit-tests/util/aws-shared-credentials-file
@@ -1,3 +1,3 @@
 [default]
-aws_access_key_id = ID
+aws_access_key_id = KEY
 aws_secret_access_key = SECRET

--- a/test/unit-tests/util/aws-shared-credentials-file
+++ b/test/unit-tests/util/aws-shared-credentials-file
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id = ID
+aws_secret_access_key = SECRET

--- a/test/unit-tests/util/aws-util.test.ts
+++ b/test/unit-tests/util/aws-util.test.ts
@@ -34,15 +34,20 @@ describe('when initializing credentials', () => {
 
     let execSpy: jest.SpyInstance<cp.ChildProcess>;
 
-    beforeAll(async () => {
+    beforeAll(() => {
+        execSpy = jest.spyOn(cp, 'exec');
+    });
+
+    beforeEach(() => {
         process.env.AWS_CONFIG_FILE = path.join(__dirname, 'aws-config-file');
         process.env.AWS_SHARED_CREDENTIALS_FILE = path.join(__dirname, 'aws-shared-credentials-file');
-        execSpy = jest.spyOn(cp, 'exec');
     });
 
     afterEach(() => {
         jest.resetAllMocks();
         jest.restoreAllMocks();
+        process.env.AWS_CONFIG_FILE = undefined;
+        process.env.AWS_SHARED_CREDENTIALS_FILE = undefined;
     });
 
     test('initialize with default profile containing access key and secret', async () => {

--- a/test/unit-tests/util/aws-util.test.ts
+++ b/test/unit-tests/util/aws-util.test.ts
@@ -36,9 +36,7 @@ describe('when initializing credentials', () => {
 
     beforeAll(() => {
         execSpy = jest.spyOn(cp, 'exec');
-    });
-
-    beforeEach(() => {
+        process.env.AWS_SDK_LOAD_CONFIG = '1';
         process.env.AWS_CONFIG_FILE = path.join(__dirname, 'aws-config-file');
         process.env.AWS_SHARED_CREDENTIALS_FILE = path.join(__dirname, 'aws-shared-credentials-file');
     });
@@ -46,6 +44,10 @@ describe('when initializing credentials', () => {
     afterEach(() => {
         jest.resetAllMocks();
         jest.restoreAllMocks();
+    });
+
+    afterAll(() => {
+        process.env.AWS_SDK_LOAD_CONFIG = undefined;
         process.env.AWS_CONFIG_FILE = undefined;
         process.env.AWS_SHARED_CREDENTIALS_FILE = undefined;
     });

--- a/test/unit-tests/util/aws-util.test.ts
+++ b/test/unit-tests/util/aws-util.test.ts
@@ -1,7 +1,17 @@
 import * as path from 'path';
+import cp, { ChildProcess, ExecException } from 'child_process';
 import * as AWSMock from 'aws-sdk-mock';
 import { examples as stsExamples } from 'aws-sdk/apis/sts-2011-06-15.examples.json';
 import { AwsUtil } from '~util/aws-util';
+
+jest.mock('child_process');
+jest.mock('../../../src/util/console-util', () => {
+    return {
+        ConsoleUtil: {
+            Readline: async() => '123456'
+        }
+    };
+});
 
 const mockResult = (output: any): jest.Mock => {
     return jest.fn().mockResolvedValue(output);
@@ -22,5 +32,94 @@ describe('when getting the master account id', () => {
 
     test('master account id is returned', () => {
         expect(masterAccountId).toBe('123456789012');
+    });
+});
+
+describe('when initializing credentials', () => {
+
+    let execSpy: jest.SpyInstance<cp.ChildProcess>;
+
+    beforeAll(async () => {
+        process.env.AWS_CONFIG_FILE = path.join(__dirname, 'aws-config-file');
+        process.env.AWS_SHARED_CREDENTIALS_FILE = path.join(__dirname, 'aws-shared-credentials-file');
+        execSpy = jest.spyOn(cp, 'exec');
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    test('initialize with default profile containing access key and secret', async () => {
+        const credentials = await AwsUtil.InitializeWithProfile(null);
+        expect(credentials).toMatchObject({
+            profile: 'default',
+            accessKeyId: 'ID',
+            secretAccessKey: 'SECRET',
+            sessionToken: undefined
+        });
+    });
+
+    test('initialize with profile containing mfa', async () => {
+        try {
+            const credentials = await AwsUtil.InitializeWithProfile('mfa');
+            // To mock this properly, we would need to setup a network interceptor
+            expect(credentials).toMatchObject({
+                profile: 'mfa',
+                accessKeyId: expect.any(String),
+                secretAccessKey: expect.any(String),
+                sessionToken: expect.any(String)
+            });
+        } catch (err) {
+            expect(err.message).toBe('Profile mfa did not include credential process');
+        }
+    });
+
+    test('initialize with profile containing credential process', async () => {
+        const mockProcess = '{"Version": 1,"Profile": "credential-process","AccessKeyId": "ID","SecretAccessKey": "SECRET","SessionToken": "SESSION","Expiration": ""}';
+        execSpy.mockImplementation(function(
+            this: ChildProcess,
+            _command: string,
+            _options: any,
+            callback?: (error: ExecException | null, stdout: string, stderr: string) => void
+        ): ChildProcess {
+            if (!callback) {
+                callback = _options;
+            }
+            callback(undefined, mockProcess, undefined);
+            return this;
+        });
+        const credentials = await AwsUtil.InitializeWithProfile('credential-process');
+        expect(execSpy).toBeCalledTimes(1);
+        expect(credentials).toMatchObject({
+            profile: 'credential-process',
+            accessKeyId: 'ID',
+            secretAccessKey: 'SECRET',
+            sessionToken: 'SESSION'
+        });
+    });
+
+    test('initialize with profile containing aws sso config', async () => {
+        const mockProcess = '{"Version": 1,"Profile": "aws-sso","AccessKeyId": "ID","SecretAccessKey": "SECRET","SessionToken": "SESSION","Expiration": ""}';
+        execSpy.mockImplementation(function(
+            this: ChildProcess,
+            _command: string,
+            _options: any,
+            callback?: (error: ExecException | null, stdout: string, stderr: string) => void
+        ): ChildProcess {
+            if (!callback) {
+                callback = _options;
+            }
+            callback(undefined, mockProcess, undefined);
+            return this;
+        });
+        const credentials = await AwsUtil.InitializeWithProfile('aws-sso');
+        expect(execSpy).toBeCalledTimes(1);
+        expect(credentials).toMatchObject({
+            profile: 'aws-sso',
+            accessKeyId: expect.any(String),
+            secretAccessKey: expect.any(String),
+            sessionToken: expect.any(String)
+        });
     });
 });


### PR DESCRIPTION
This will add support for credential process and AWS SSO within the AWS CLI config file as well as simplify the profile with MFA. ~~By leveraging a tool like [aws-sso-util](https://github.com/benkehoe/aws-sso-util), users can set AWS SSO even though the AWS SDK does not support it yet.~~ We are using a NPM library to load the AWS SSO configuration now.

Related to #123 