### PR TITLE
support using !FindInMap together with !Ref CurrentAccount

### DIFF
--- a/src/build-tasks/build-task-provider.ts
+++ b/src/build-tasks/build-task-provider.ts
@@ -7,6 +7,7 @@ import { IPerformTasksCommandArgs }  from '~commands/index';
 import { ITrackedTask } from '~state/persisted-state';
 import { PluginProvider } from '~plugin/plugin';
 import { PluginBuildTaskProvider } from '~plugin/plugin-task';
+import { CfnExpressionResolver } from '~core/cfn-expression-resolver';
 
 export class BuildTaskProvider {
     private static SingleInstance: BuildTaskProvider;
@@ -35,27 +36,27 @@ export class BuildTaskProvider {
     }
 
 
-    public static createValidationTask(configuration: IBuildTaskConfiguration, command: IPerformTasksCommandArgs): IBuildTask {
+    public static createValidationTask(configuration: IBuildTaskConfiguration, command: IPerformTasksCommandArgs, resolver: CfnExpressionResolver): IBuildTask {
         const taskProvider = this.GetBuildTaskProvider();
         const provider = taskProvider.providers[configuration.Type];
         if (provider === undefined) {throw new OrgFormationError(`unable to load file ${configuration.FilePath}, unknown configuration type ${configuration.Type}`);}
-        const validationTask = provider.createTaskForValidation(configuration, command);
+        const validationTask = provider.createTaskForValidation(configuration, command, resolver);
         return validationTask;
     }
 
-    static createPrintTask(configuration: IBuildTaskConfiguration, command: IPerformTasksCommandArgs): IBuildTask {
+    static createPrintTask(configuration: IBuildTaskConfiguration, command: IPerformTasksCommandArgs, resolver: CfnExpressionResolver): IBuildTask {
         const taskProvider = this.GetBuildTaskProvider();
         const provider = taskProvider.providers[configuration.Type];
         if (provider === undefined) {throw new OrgFormationError(`unable to load file ${configuration.FilePath}, unknown configuration type ${configuration.Type}`);}
-        const validationTask = provider.createTaskForPrint(configuration, command);
+        const validationTask = provider.createTaskForPrint(configuration, command, resolver);
         return validationTask;
     }
 
-    public static createBuildTask(configuration: IBuildTaskConfiguration, command: IPerformTasksCommandArgs): IBuildTask {
+    public static createBuildTask(configuration: IBuildTaskConfiguration, command: IPerformTasksCommandArgs, resolver: CfnExpressionResolver): IBuildTask {
         const taskProvider = this.GetBuildTaskProvider();
         const provider = taskProvider.providers[configuration.Type];
         if (provider === undefined) {throw new OrgFormationError(`unable to load file ${configuration.FilePath}, unknown configuration type ${configuration.Type}`);}
-        const task = provider.createTask(configuration, command);
+        const task = provider.createTask(configuration, command, resolver);
         return task;
     }
 
@@ -110,8 +111,8 @@ export class BuildTaskProvider {
 
 export interface IBuildTaskProvider<TConfig extends IBuildTaskConfiguration> {
     type: string;
-    createTask(config: TConfig, command: IPerformTasksCommandArgs): IBuildTask;
-    createTaskForValidation(config: TConfig, command: IPerformTasksCommandArgs): IBuildTask | undefined;
-    createTaskForPrint(config: TConfig, command: IPerformTasksCommandArgs): IBuildTask | undefined;
-    createTaskForCleanup(logicalId: string, physicalId: string, command: IPerformTasksCommandArgs): IBuildTask | undefined;
+    createTask(config: TConfig, command: IPerformTasksCommandArgs, resolver?: CfnExpressionResolver): IBuildTask;
+    createTaskForValidation(config: TConfig, command: IPerformTasksCommandArgs, resolver?: CfnExpressionResolver): IBuildTask | undefined;
+    createTaskForPrint(config: TConfig, command: IPerformTasksCommandArgs, resolver?: CfnExpressionResolver): IBuildTask | undefined;
+    createTaskForCleanup(logicalId: string, physicalId: string, command: IPerformTasksCommandArgs, resolver?: CfnExpressionResolver): IBuildTask | undefined;
 }

--- a/src/build-tasks/tasks/update-stacks-task.ts
+++ b/src/build-tasks/tasks/update-stacks-task.ts
@@ -7,12 +7,13 @@ import { Validator } from '~parser/validator';
 import { IBuildTaskProvider, BuildTaskProvider } from '~build-tasks/build-task-provider';
 import { IOrganizationBinding } from '~parser/parser';
 import { FileUtil } from '~util/file-util';
+import { CfnExpressionResolver } from '~core/cfn-expression-resolver';
 
 
 export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdateStackTaskConfiguration> {
     public type = 'update-stacks';
 
-    createTask(config: IUpdateStackTaskConfiguration, command: IPerformTasksCommandArgs): IUpdateStacksBuildTask {
+    createTask(config: IUpdateStackTaskConfiguration, command: IPerformTasksCommandArgs, resolver: CfnExpressionResolver): IUpdateStacksBuildTask {
 
         Validator.ValidateUpdateStacksTask(config, config.LogicalName);
 
@@ -26,6 +27,7 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
             isDependency: BuildTaskProvider.createIsDependency(config),
             perform: async (): Promise<void> => {
                 const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command);
+                updateStacksCommand.resolver = resolver;
                 ConsoleUtil.LogInfo(`Executing: ${config.Type} ${updateStacksCommand.templateFile} ${updateStacksCommand.stackName}.`);
                 await UpdateStacksCommand.Perform(updateStacksCommand);
             },
@@ -33,7 +35,7 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
         return task;
     }
 
-    createTaskForValidation(config: IUpdateStackTaskConfiguration, command: IPerformTasksCommandArgs): IUpdateStacksBuildTask {
+    createTaskForValidation(config: IUpdateStackTaskConfiguration, command: IPerformTasksCommandArgs, resolver: CfnExpressionResolver): IUpdateStacksBuildTask {
         return {
             type: config.Type,
             name: config.LogicalName,
@@ -43,12 +45,13 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
             isDependency: BuildTaskProvider.createIsDependency(config),
             perform: async (): Promise<void> => {
                 const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command);
+                updateStacksCommand.resolver = resolver;
                 await ValidateStacksCommand.Perform(updateStacksCommand);
             },
         };
     }
 
-    createTaskForPrint(config: IUpdateStackTaskConfiguration, command: IPerformTasksCommandArgs): IUpdateStacksBuildTask {
+    createTaskForPrint(config: IUpdateStackTaskConfiguration, command: IPerformTasksCommandArgs, resolver: CfnExpressionResolver): IUpdateStacksBuildTask {
         return {
             type: config.Type,
             name: config.LogicalName,
@@ -58,6 +61,7 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
             isDependency: BuildTaskProvider.createIsDependency(config),
             perform: async (): Promise<void> => {
                 const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command);
+                updateStacksCommand.resolver = resolver;
                 await PrintStacksCommand.Perform({...updateStacksCommand, stackName: config.StackName });
             },
         };

--- a/src/cfn-binder/cfn-task-provider.ts
+++ b/src/cfn-binder/cfn-task-provider.ts
@@ -14,7 +14,7 @@ export class CfnTaskProvider {
 
     }
 
-    public async createUpdateTemplateTask(binding: ICfnBinding): Promise<ICfnTask> {
+    public async createUpdateTemplateTask(binding: ICfnBinding, parentResolver?: CfnExpressionResolver): Promise<ICfnTask> {
         const that = this;
         const dependencies: ICrossAccountParameterDependency[] = [];
         const boundParameters = binding.template.enumBoundParameters();
@@ -41,6 +41,10 @@ export class CfnTaskProvider {
         }
 
         const expressionResolver = CfnExpressionResolver.CreateDefaultResolver(binding.accountLogicalId, binding.accountId, binding.region, binding.customRoleName, binding.customViaRoleArn, this.template.organizationSection, this.state, true);
+        if (parentResolver !== undefined) {
+            expressionResolver.mapping = parentResolver.mapping;
+            expressionResolver.filePath = parentResolver.filePath;
+        }
         const stackName = await expressionResolver.resolveSingleExpression(binding.stackName, 'StackName');
 
         return {
@@ -185,10 +189,14 @@ export class CfnTaskProvider {
         };
     }
 
-    public async createDeleteTemplateTask(binding: ICfnBinding): Promise<ICfnTask> {
+    public async createDeleteTemplateTask(binding: ICfnBinding, parentResolver?: CfnExpressionResolver): Promise<ICfnTask> {
         const that = this;
 
         const expressionResolver = CfnExpressionResolver.CreateDefaultResolver(binding.accountLogicalId, binding.accountId, binding.region, binding.customRoleName, binding.customViaRoleArn, this.template.organizationSection, this.state, true);
+        if (parentResolver !== undefined) {
+            expressionResolver.mapping = parentResolver.mapping;
+            expressionResolver.filePath = parentResolver.filePath;
+        }
         const stackName = await expressionResolver.resolveSingleExpression(binding.stackName, 'StackName');
 
         return {

--- a/src/commands/update-stacks.ts
+++ b/src/commands/update-stacks.ts
@@ -7,6 +7,7 @@ import { CfnTaskRunner } from '~cfn-binder/cfn-task-runner';
 import { IOrganizationBinding, ITemplateOverrides, TemplateRoot } from '~parser/parser';
 import { Validator } from '~parser/validator';
 import { GlobalState } from '~util/global-state';
+import { CfnExpressionResolver } from '~core/cfn-expression-resolver';
 
 const commandName = 'update-stacks <templateFile>';
 const commandDescription = 'update CloudFormation resources in accounts';
@@ -127,7 +128,7 @@ export class UpdateStacksCommand extends BaseCliCommand<IUpdateStacksCommandArgs
         const state = await this.getState(command);
         GlobalState.Init(state, template);
 
-        const cfnBinder = new CloudFormationBinder(stackName, template, state, parameters, command.forceDeploy === true, command.verbose === true, taskRoleName, terminationProtection, stackPolicy, cloudFormationRoleName, undefined, taskViaRoleArn);
+        const cfnBinder = new CloudFormationBinder(stackName, template, state, parameters, command.forceDeploy === true, command.verbose === true, taskRoleName, terminationProtection, stackPolicy, cloudFormationRoleName, command.resolver, undefined, taskViaRoleArn);
 
         const cfnTasks = await cfnBinder.enumTasks();
         if (cfnTasks.length === 0) {
@@ -163,4 +164,5 @@ export interface IUpdateStacksCommandArgs extends ICommandArgs {
     taskRoleName?: string;
     taskViaRoleArn?: string;
     stackPolicy?: {};
+    resolver?: CfnExpressionResolver;
 }

--- a/src/commands/validate-stacks.ts
+++ b/src/commands/validate-stacks.ts
@@ -50,7 +50,7 @@ export class ValidateStacksCommand extends BaseCliCommand<IUpdateStacksCommandAr
         const stackPolicy = command.stackPolicy;
         const cloudFormationRoleName = command.cloudFormationRoleName;
         const taskViaRoleArn = command.taskViaRoleArn;
-        const cfnBinder = new CloudFormationBinder(command.stackName, template, state, parameters, false, command.verbose === true, command.taskRoleName, false, stackPolicy, cloudFormationRoleName, undefined, taskViaRoleArn);
+        const cfnBinder = new CloudFormationBinder(command.stackName, template, state, parameters, false, command.verbose === true, command.taskRoleName, false, stackPolicy, cloudFormationRoleName, command.resolver, undefined, taskViaRoleArn);
 
         const bindings = await cfnBinder.enumBindings();
 

--- a/src/core/cfn-expression-resolver.ts
+++ b/src/core/cfn-expression-resolver.ts
@@ -24,8 +24,8 @@ export class CfnExpressionResolver {
     readonly resolvers: Record<string, IResolver> = {};
     readonly globalResolvers: IResolver[] = [];
     readonly treeResolvers: ITreeResolver<any>[] = [];
-    private mapping: CfnMappingsSection;
-    private filePath: string;
+    mapping: CfnMappingsSection;
+    filePath: string;
 
     addResourceWithAttributes(resource: string, attributes: Record<string, string>): void {
         this.resolvers[resource] = { resolve: (resolver: CfnExpressionResolver, resourceName: string, path?: string): string => {

--- a/test/integration-tests/resources/scenario-cfn-parameter-expressions/1-deploy-update-stacks-with-param-expressions.yml
+++ b/test/integration-tests/resources/scenario-cfn-parameter-expressions/1-deploy-update-stacks-with-param-expressions.yml
@@ -25,6 +25,10 @@ Mappings:
     MyGroup2:
       MyKey: [MyVal2]
       MyKey2: [MyVal22]
+  UsingAccount:
+    IpAddresses:
+      102625093955: 10.201.30
+      340381375986: 10.201.31
 
 
 OrganizationUpdate:
@@ -78,6 +82,7 @@ PolicyTemplate:
     md5readFile: !MD5
       - !ReadFile ./file.txt
     cmd: !Cmd 'echo "check command"'
+    ip: !FindInMap [UsingAccount, IpAddresses, !Ref CurrentAccount]
     select: !Select [2, ['one', 'two', 'three']]
     selectFindInMap: !Select [0, !FindInMap [MyMapWithArrarys, MyGroup1, MyKey]]
     jsonString1: !JsonString

--- a/test/integration-tests/resources/scenario-cfn-parameter-expressions/bucket-policy.yml
+++ b/test/integration-tests/resources/scenario-cfn-parameter-expressions/bucket-policy.yml
@@ -82,6 +82,10 @@ Parameters:
 
   refToAccountBinding:
     Type: String
+  ip:
+    Type: String
+  cmd:
+    Type: String
 
 Resources:
   BucketPolicy:

--- a/test/integration-tests/scenario-update-stacks-with-param-expressions.test.ts
+++ b/test/integration-tests/scenario-update-stacks-with-param-expressions.test.ts
@@ -188,6 +188,12 @@ describe('when importing value from another stack', () => {
         expect(parameter.ParameterValue).toBe('check command');
     })
 
+    test('find in map can be used with !Ref CurrentAccount', () =>{
+        expect(describeBucketRoleStack).toBeDefined();
+
+        const parameter = describeBucketRoleStack.Stacks[0].Parameters.find(x=>x.ParameterKey === 'ip');
+        expect(parameter.ParameterValue).toBe('10.201.30');
+    })
     test('select gets resolved properly', () =>{
         expect(describeBucketRoleStack).toBeDefined();
 

--- a/test/unit-tests/build-tasks/build-configuration.test.ts
+++ b/test/unit-tests/build-tasks/build-configuration.test.ts
@@ -6,6 +6,7 @@ import { ConsoleUtil } from '~util/console-util';
 import { IUpdateStackTaskConfiguration } from '~build-tasks/tasks/update-stacks-task';
 import { IPerformTasksCommandArgs } from '~commands/index';
 import { assert } from 'console';
+import { CfnExpressionResolver } from '~core/cfn-expression-resolver';
 
 
 
@@ -159,7 +160,7 @@ describe('when creating build configuration', () => {
             MaxConcurrentStacks: 1,
             FailedStackTolerance: 1,
         };
-        task = BuildTaskProvider.createBuildTask(config, {} as IPerformTasksCommandArgs);
+        task = BuildTaskProvider.createBuildTask(config, {} as IPerformTasksCommandArgs, new CfnExpressionResolver());
 
         updateStacksResources = sandbox.stub(UpdateStacksCommand, 'Perform');
         sandbox.stub(ConsoleUtil, 'LogInfo')
@@ -182,7 +183,7 @@ describe('when creating build configuration', () => {
         const commandKeys = Object.keys(commandArgs);
 
         expect(fileArg.endsWith('path.yml')).toBe(true);
-        expect(commandKeys.length).toBe(5);
+        expect(commandKeys.length).toBe(6);
         expect(commandKeys).toEqual(expect.arrayContaining(['stackName']));
         expect(commandArgs.stackName).toBe('stack');
     });

--- a/test/unit-tests/build-tasks/build-task-provider.test.ts
+++ b/test/unit-tests/build-tasks/build-task-provider.test.ts
@@ -5,6 +5,7 @@ import { IUpdateStacksCommandArgs, UpdateStacksCommand } from '~commands/update-
 import { ConsoleUtil } from '~util/console-util';
 import { IUpdateStackTaskConfiguration } from '~build-tasks/tasks/update-stacks-task';
 import { IPerformTasksCommandArgs } from '~commands/index';
+import { CfnExpressionResolver } from '~core/cfn-expression-resolver';
 
 describe('when creating UpdateStacksTask task', () => {
     let task: IBuildTask;
@@ -20,7 +21,7 @@ describe('when creating UpdateStacksTask task', () => {
             MaxConcurrentStacks: 1,
             FailedStackTolerance: 1,
         };
-        task = BuildTaskProvider.createBuildTask(config, {} as IPerformTasksCommandArgs);
+        task = BuildTaskProvider.createBuildTask(config, {} as IPerformTasksCommandArgs, new CfnExpressionResolver());
 
         updateStacksResources = sandbox.stub(UpdateStacksCommand, 'Perform');
         sandbox.stub(ConsoleUtil, 'LogInfo')
@@ -40,7 +41,7 @@ describe('when creating UpdateStacksTask task', () => {
         const commandKeys = Object.keys(commandArgs);
 
         expect(fileArg.endsWith('path.yml')).toBe(true);
-        expect(commandKeys.length).toBe(5);
+        expect(commandKeys.length).toBe(6);
         expect(commandKeys).toEqual(expect.arrayContaining(['stackName']));
         expect(commandArgs.stackName).toBe('stack');
     });
@@ -60,7 +61,7 @@ describe('when creating UpdateStacksTask task with command args', () => {
             MaxConcurrentStacks: 1,
             FailedStackTolerance: 1,
         };
-        task = BuildTaskProvider.createBuildTask(config, { arg: 'Val' } as any);
+        task = BuildTaskProvider.createBuildTask(config, { arg: 'Val' } as any, new CfnExpressionResolver());
         updateStacksResources = sandbox.stub(UpdateStacksCommand, 'Perform');
         sandbox.stub(ConsoleUtil, 'LogInfo');
     });
@@ -79,7 +80,7 @@ describe('when creating UpdateStacksTask task with command args', () => {
             const commandKeys = Object.keys(commandArgs);
 
             expect(fileArg.endsWith('path.yml')).toBe(true);
-            expect(commandKeys.length).toBe(6);
+            expect(commandKeys.length).toBe(7);
             expect(commandKeys).toEqual(expect.arrayContaining(['stackName']));
             expect(commandArgs.stackName).toBe('stack');
             expect(commandKeys).toEqual(expect.arrayContaining(['arg']));
@@ -118,7 +119,7 @@ describe('when creating UpdateStacksTask task with old attribute names', () => {
             MaxConcurrentStacks: 1,
             FailedStackTolerance: 1,
         };
-        task = BuildTaskProvider.createBuildTask(config, { arg: 'Val' } as any);
+        task = BuildTaskProvider.createBuildTask(config, { arg: 'Val' } as any, new CfnExpressionResolver());
         updateStacksResources = sandbox.stub(UpdateStacksCommand, 'Perform');
         sandbox.stub(ConsoleUtil, 'LogInfo');
         await task.perform();
@@ -138,7 +139,7 @@ describe('when creating UpdateStacksTask task with old attribute names', () => {
         const commandKeys = Object.keys(commandArgs);
 
         expect(fileArg.endsWith('path.yml')).toBe(true);
-        expect(commandKeys.length).toBe(10);
+        expect(commandKeys.length).toBe(11);
         expect(commandKeys).toEqual(expect.arrayContaining(['stackName']));
         expect(commandArgs.stackName).toBe('stack');
         expect(commandKeys).toEqual(expect.arrayContaining(['arg']));
@@ -155,7 +156,7 @@ describe('when creating UpdateStacksTask task with old attribute names', () => {
 describe('when creating UpdateStacksTask task', () => {
     let task: IBuildTask;
     const sandbox = Sinon.createSandbox();
-    let updateStacksResoruces: sinon.SinonStub;
+    let updateStacksResources: sinon.SinonStub;
 
     beforeEach(() => {
         const config: IUpdateStackTaskConfiguration = {
@@ -178,8 +179,8 @@ describe('when creating UpdateStacksTask task', () => {
             MaxConcurrentStacks: 1,
             FailedStackTolerance: 1,
         };
-        task = BuildTaskProvider.createBuildTask(config, { arg: 'Val' } as any);
-        updateStacksResoruces = sandbox.stub(UpdateStacksCommand, 'Perform');
+        task = BuildTaskProvider.createBuildTask(config, { arg: 'Val' } as any, new CfnExpressionResolver());
+        updateStacksResources = sandbox.stub(UpdateStacksCommand, 'Perform');
         sandbox.stub(ConsoleUtil, 'LogInfo');
     });
     afterEach(() => {
@@ -188,12 +189,12 @@ describe('when creating UpdateStacksTask task', () => {
 
     test('all arguments are passed to updateStackResources', async () => {
         await task.perform();
-        const commandArgs = updateStacksResoruces.lastCall.args[0] as IUpdateStacksCommandArgs;
+        const commandArgs = updateStacksResources.lastCall.args[0] as IUpdateStacksCommandArgs;
         const fileArg = commandArgs.templateFile;
         const commandKeys = Object.keys(commandArgs);
 
         expect(fileArg.endsWith('path.yml')).toBe(true);
-        expect(commandKeys.length).toBe(10);
+        expect(commandKeys.length).toBe(11);
         expect(commandKeys).toEqual(expect.arrayContaining(['stackName']));
         expect(commandArgs.stackName).toBe('stack');
         expect(commandKeys).toEqual(expect.arrayContaining(['arg']));

--- a/test/unit-tests/templates/tasks.test.ts
+++ b/test/unit-tests/templates/tasks.test.ts
@@ -1,5 +1,4 @@
 import { BuildConfiguration, IBuildTask } from '~build-tasks/build-configuration';
-import { BaseOrganizationTask } from '~build-tasks/tasks/organization-task';
 import { BaseCliCommand } from '~commands/base-command';
 import Sinon = require('sinon');
 import { CfnTaskRunner } from '~cfn-binder/cfn-task-runner';
@@ -9,43 +8,42 @@ import { ICfnTask } from '~cfn-binder/cfn-task-provider';
 import { ConsoleUtil } from '~util/console-util';
 import { IPerformTasksCommandArgs } from '~commands/index';
 import { IUpdateStacksBuildTask } from '~build-tasks/tasks/update-stacks-task';
-import { config } from 'aws-sdk';
 
 describe('when loading task file configuration', () => {
-    let buildconfig: BuildConfiguration;
+    let buildConfig: BuildConfiguration;
 
     beforeEach(() => {
-        buildconfig = new BuildConfiguration('./test/resources/tasks/build-tasks.yml');
+        buildConfig = new BuildConfiguration('./test/resources/tasks/build-tasks.yml');
     });
 
     test('loads build configuration', () => {
-        expect(buildconfig).toBeDefined();
+        expect(buildConfig).toBeDefined();
     });
 
     test('has configuration per task', () => {
-        expect(buildconfig.tasks.length).toBe(5);
-        expect(buildconfig.tasks.find((x) => x.LogicalName === 'CfnTemplate')).toBeDefined();
-        expect(buildconfig.tasks.find((x) => x.LogicalName === 'OrgTemplate')).toBeDefined();
-        expect(buildconfig.tasks.find((x) => x.LogicalName === 'OrganizationUpdate')).toBeDefined();
-        expect(buildconfig.tasks.find((x) => x.LogicalName === 'Include1')).toBeDefined();
-        expect(buildconfig.tasks.find((x) => x.LogicalName === 'Include2')).toBeDefined();
+        expect(buildConfig.tasks.length).toBe(5);
+        expect(buildConfig.tasks.find((x) => x.LogicalName === 'CfnTemplate')).toBeDefined();
+        expect(buildConfig.tasks.find((x) => x.LogicalName === 'OrgTemplate')).toBeDefined();
+        expect(buildConfig.tasks.find((x) => x.LogicalName === 'OrganizationUpdate')).toBeDefined();
+        expect(buildConfig.tasks.find((x) => x.LogicalName === 'Include1')).toBeDefined();
+        expect(buildConfig.tasks.find((x) => x.LogicalName === 'Include2')).toBeDefined();
     });
 
     test('all tasks have FilePath', () => {
-        const withoutFileName = buildconfig.tasks.find((x) => !x.FilePath);
+        const withoutFileName = buildConfig.tasks.find((x) => !x.FilePath);
         expect(withoutFileName).toBeUndefined();
     });
 });
 
 describe('when enumerating build tasks', () => {
-    let buildconfig: BuildConfiguration;
+    let buildConfig: BuildConfiguration;
 
     beforeEach(() => {
-        buildconfig = new BuildConfiguration('./test/resources/tasks/build-tasks.yml');
+        buildConfig = new BuildConfiguration('./test/resources/tasks/build-tasks.yml');
     });
 
     test('every build config gets a task', () => {
-        const tasks = buildconfig.enumBuildTasks({} as any);
+        const tasks = buildConfig.enumBuildTasks({} as any);
         expect(tasks).toBeDefined();
         expect(tasks.length).toBe(5);
         expect(tasks.filter((x) => x.type === 'include').length).toBe(2);
@@ -54,7 +52,7 @@ describe('when enumerating build tasks', () => {
     });
 
     test('include tasks have child tasks', () => {
-        const tasks = buildconfig.enumBuildTasks({} as any);
+        const tasks = buildConfig.enumBuildTasks({} as any);
         const includes = tasks.filter((x) => x.type === 'include');
         expect(includes[0].childTasks.length).toBe(2);
         expect(includes[1].childTasks.length).toBe(2);


### PR DESCRIPTION
allows for variations in template parameters based on !Ref CurrentAccount in a tasks file

e.g.
``` yml
Mappings:
  MyMap:
    IpAddresses:
      112233112233: 10.201.30
      112233112234: 10.201.31
      
MyStack:
  Type: update-stacks
  Template: ./template.yml
  StackName: just-an-example
  Parameters:
    ip: !FindInMap [MyMap, IpAddresses, !Ref CurrentAccount]
```
closes  #206