### PR TITLE
Docs Template - Increase Budget Threshold to 90%

### DIFF
--- a/examples/templates/budget-alarms.yml
+++ b/examples/templates/budget-alarms.yml
@@ -48,7 +48,7 @@ Resources:
         - Notification:
             NotificationType: FORECASTED
             ComparisonOperator: GREATER_THAN
-            Threshold: 1
+            Threshold: 90
           Subscribers:
             - SubscriptionType: SNS
               Address: !Ref BudgetAlarmTopic


### PR DESCRIPTION
Changing this to 90% as 1% seems incorrect. Changing this also requires all budgets are manually deleted as per https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/365 so a more sensible doc default seems like a good idea.