### PR TITLE
Fix delete-stack CLI Docs

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -171,7 +171,7 @@ Lists all stacks deployed to accounts using org-formation
 
 Will delete all stacks of name *stackName* that have been deployed using org-formation.
 
-``> org-formation delete-stacks stackName``
+``> org-formation delete-stacks --stack-name my-stack``
 
 |option|default|description|
 |---|---|---|

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -169,7 +169,7 @@ Lists all stacks deployed to accounts using org-formation
 
 ### ``org-formation delete-stacks``
 
-Will delete all stacks of name *stackName* that have been deployed using org-formation.
+Will delete all stacks of name *my-stack* that have been deployed using org-formation.
 
 ``> org-formation delete-stacks --stack-name my-stack``
 


### PR DESCRIPTION
Fixes `ERROR: argument --stack-name is missing`