### PR TITLE
The ARG command should be after FROM command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
+FROM        node:12.18-alpine3.11
 # release version passed in on build, just default it temporarily
 ARG         RELEASE_VERSION=0.0.1
-
-FROM        node:12.18-alpine3.11
 RUN         npm install -g --production aws-organization-formation@${RELEASE_VERSION}
 WORKDIR     /workdir
 ENV         AWS_PROFILE=default


### PR DESCRIPTION
I noticed that the `build-arg` for `RELEASE_VERSION` in the github action was not behaving as expected in a different but similar repo.  The same issue is present here.  This PR fixes the issue.