### PR TITLE
fix: clarify workaround custom rps

### DIFF
--- a/src/plugin/impl/rp-build-task-plugin.ts
+++ b/src/plugin/impl/rp-build-task-plugin.ts
@@ -136,7 +136,7 @@ export class RpBuildTaskPlugin implements IBuildTaskPlugin<IRpBuildTaskConfig, I
     private async ensureExecutionRole(cfn: CloudFormation, handlerPackageUrl: string): Promise<string> {
 
         if (handlerPackageUrl === undefined || !handlerPackageUrl.startsWith(communityResourceProviderCatalogS3Path)) {
-            throw new OrgFormationError('Can only automatically install ExecutionRole for resource providers hosted on community-resource-provider-catalog. As a workaround, you could just use the native cloudformation resource to actually register the type: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-resourceversion.html');
+            throw new OrgFormationError('Can only automatically install ExecutionRole for resource providers hosted on community-resource-provider-catalog. As a workaround, you can use the native CloudFormation resource to register the type: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-resourceversion.html');
         }
 
         const { name, version } = this.getResourceRoleName(handlerPackageUrl);


### PR DESCRIPTION
related to #233. i think the direction should be to point people in the direction of AWS provided CFN types for registration. the registr-type action was a temporary solution in absence of AWS native support.