### PR TITLE
feat: partition pseudo parameter in tasks

### DIFF
--- a/src/build-tasks/build-configuration.ts
+++ b/src/build-tasks/build-configuration.ts
@@ -12,6 +12,7 @@ import { CfnMappingsSection } from '~core/cfn-functions/cfn-find-in-map';
 import { yamlParseWithIncludes } from '~yaml-cfn/yaml-parse-includes';
 import { ConsoleUtil } from '~util/console-util';
 import { TemplateRoot } from '~parser/parser';
+import { AwsUtil } from '~util/aws-util';
 
 export class BuildConfiguration {
     public tasks: IBuildTaskConfiguration[];
@@ -186,6 +187,7 @@ export class BuildConfiguration {
         }
         this.resolver.addMappings(this.mappings);
         this.resolver.setFilePath(filePath);
+        this.resolver.addParameter('AWS::Partition', AwsUtil.partition);
         const resolvedContents = this.resolver.resolveFirstPass(buildFile);
 
         const result: IBuildTaskConfiguration[] = [];

--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -155,7 +155,7 @@ export abstract class BaseCliCommand<T extends ICommandArgs> {
         }
         const masterAccountId = await AwsUtil.GetMasterAccountId();
         const organizations = await AwsUtil.GetOrganizationsService(masterAccountId, roleInMasterAccount);
-        const crossAccountConfig = { masterAccountId, masterAccountRoleName: roleInMasterAccount};
+        const crossAccountConfig = { masterAccountId, masterAccountRoleName: roleInMasterAccount };
 
         const awsReader = new AwsOrganizationReader(organizations, crossAccountConfig);
         const awsOrganization = new AwsOrganization(awsReader);
@@ -203,7 +203,7 @@ export abstract class BaseCliCommand<T extends ICommandArgs> {
     protected static async GetStateBucketName(stateBucketName: string, accountId?: string): Promise<string> {
         const bucketName = stateBucketName || 'organization-formation-${AWS::AccountId}';
         if (bucketName.indexOf('${AWS::AccountId}') >= 0) {
-            if (accountId === undefined){
+            if (accountId === undefined) {
                 accountId = await AwsUtil.GetBuildProcessAccountId();
             }
             return bucketName.replace('${AWS::AccountId}', accountId);
@@ -211,7 +211,7 @@ export abstract class BaseCliCommand<T extends ICommandArgs> {
         return bucketName;
     }
 
-    protected parseCfnParameters(commandParameters?: string | undefined | {}): Record<string, string>  {
+    protected parseCfnParameters(commandParameters?: string | undefined | {}): Record<string, string> {
 
         if (typeof commandParameters === 'object') {
             return commandParameters;
@@ -255,12 +255,14 @@ export abstract class BaseCliCommand<T extends ICommandArgs> {
             AwsUtil.SetMasterAccountId(command.masterAccountId);
         }
 
+        await AwsUtil.InitializeWithCurrentPartition();
+
         command.initialized = true;
     }
 
     private loadRuntimeConfiguration(command: ICommandArgs): void {
         const rc = RC('org-formation', {}, {}) as IRCObject;
-        if (rc.configs !== undefined){
+        if (rc.configs !== undefined) {
 
             if (rc.organizationFile && rc.config && !rc.organizationFile.startsWith('s3://')) {
                 const dir = path.dirname(rc.config);

--- a/test/integration-tests/resources/scenario-task-file-parameters/1-task-file-with-parameters.yml
+++ b/test/integration-tests/resources/scenario-task-file-parameters/1-task-file-with-parameters.yml
@@ -12,6 +12,9 @@ Parameters:
     Type: Boolean
     Default: true
 
+  region:
+    Type: String
+    Default: eu-west-1
 
 OrganizationUpdate:
   Type: update-organization
@@ -22,7 +25,7 @@ BucketTemplate:
   Type: update-stacks
   Template: ./bucket.yml
   StackName: !Sub ${stackPrefix}-scenario-stack-parameters
-  DefaultOrganizationBindingRegion: eu-west-1
+  DefaultOrganizationBindingRegion: !Ref region
   DefaultOrganizationBinding:
     IncludeMasterAccount: !Ref includeMasterAccount
 
@@ -32,3 +35,22 @@ includeOther:
   Path: ./included-task-file.yml
   Parameters:
     stackPrefix: something-else
+    partition: aws
+
+# parameter must be supplied by perform-tasks
+includeWithoutPartitionParam:
+  DependsOn: BucketTemplate
+  Type: include
+  Path: ./included-task-file.yml
+  Parameters:
+    stackPrefix: something-different
+
+
+# parameter must be supplied by perform-tasks
+includeWithPseudoParam:
+  DependsOn: BucketTemplate
+  Type: include
+  Path: ./included-task-file-with-pseudo-param.yml
+  Parameters:
+    stackPrefix: something-with-pseudo-param
+

--- a/test/integration-tests/resources/scenario-task-file-parameters/included-task-file-with-pseudo-param.yml
+++ b/test/integration-tests/resources/scenario-task-file-parameters/included-task-file-with-pseudo-param.yml
@@ -1,17 +1,9 @@
 
 Parameters:
 
-  partition:
-    Type: String
-
   stackPrefix:
     Description:
     Type: String
-
-  includeMasterAccount:
-    Description:
-    Type: Boolean
-    Default: true
 
 Mappings:
   Partition:
@@ -23,6 +15,6 @@ BucketTemplate:
   Type: update-stacks
   Template: ./bucket.yml
   StackName: !Sub ${stackPrefix}-scenario-stack-parameters
-  DefaultOrganizationBindingRegion: !FindInMap [ Partition, BindingRegions, !Ref partition ]
+  DefaultOrganizationBindingRegion: !FindInMap [ Partition, BindingRegions, !Ref AWS::Partition ]
   DefaultOrganizationBinding:
-    IncludeMasterAccount: !Ref includeMasterAccount
+    IncludeMasterAccount: true

--- a/test/integration-tests/resources/scenario-task-file-parameters/included-task-file-with-pseudo-param.yml
+++ b/test/integration-tests/resources/scenario-task-file-parameters/included-task-file-with-pseudo-param.yml
@@ -5,6 +5,11 @@ Parameters:
     Description:
     Type: String
 
+  includeMasterAccount:
+    Description:
+    Type: Boolean
+    Default: true
+
 Mappings:
   Partition:
     BindingRegions:
@@ -17,4 +22,4 @@ BucketTemplate:
   StackName: !Sub ${stackPrefix}-scenario-stack-parameters
   DefaultOrganizationBindingRegion: !FindInMap [ Partition, BindingRegions, !Ref AWS::Partition ]
   DefaultOrganizationBinding:
-    IncludeMasterAccount: true
+    IncludeMasterAccount: !Ref includeMasterAccount

--- a/test/integration-tests/scenario-task-file-parameters.test.ts
+++ b/test/integration-tests/scenario-task-file-parameters.test.ts
@@ -1,6 +1,9 @@
 import { ValidateTasksCommand, PerformTasksCommand } from "~commands/index";
-import { IIntegrationTestContext, baseBeforeAll, baseAfterAll } from "./base-integration-test";
+import { IIntegrationTestContext, baseBeforeAll, baseAfterAll, sleepForTest } from "./base-integration-test";
 import { DescribeStacksOutput, ListStacksOutput } from "aws-sdk/clients/cloudformation";
+import { AwsUtil } from "~util/aws-util";
+import { GetObjectOutput } from "aws-sdk/clients/s3";
+import { PrintTasksCommand } from "~commands/print-tasks";
 
 const basePathForScenario = './test/integration-tests/resources/scenario-task-file-parameters/';
 
@@ -8,29 +11,35 @@ describe('when using parameters in template', () => {
     let context: IIntegrationTestContext;
     let describedStacks: DescribeStacksOutput;
     let describedStacksFromInclude: DescribeStacksOutput;
+    let describedStacksFromInclude2: DescribeStacksOutput;
+    let describedStacksFromInclude3: DescribeStacksOutput;
     let describedStacksAfterCleanup: ListStacksOutput;
 
     beforeAll(async () => {
 
-        try{
+        try {
             context = await baseBeforeAll();
 
+            await AwsUtil.InitializeWithCurrentPartition();
             await context.prepareStateBucket(basePathForScenario + '../state.json');
-            const { command, cfnClient } = context;
+            const { command, cfnClient, s3client, stateBucketName } = context;
 
-            await ValidateTasksCommand.Perform({...command, tasksFile: basePathForScenario + '1-task-file-with-parameters.yml' })
-            await PerformTasksCommand.Perform({...command, tasksFile: basePathForScenario + '1-task-file-with-parameters.yml' });
+            await ValidateTasksCommand.Perform({ ...command, tasksFile: basePathForScenario + '1-task-file-with-parameters.yml', parameters: "partition=aws" });
+            await PrintTasksCommand.Perform({ ...command, tasksFile: basePathForScenario + '1-task-file-with-parameters.yml', parameters: "partition=aws" });
+            await PerformTasksCommand.Perform({ ...command, tasksFile: basePathForScenario + '1-task-file-with-parameters.yml', parameters: "partition=aws" });
+            await sleepForTest(1000);
 
-            describedStacks = await cfnClient.describeStacks({StackName: 'my-scenario-stack-parameters'}).promise();
-            describedStacksFromInclude = await cfnClient.describeStacks({StackName: 'something-else-scenario-stack-parameters'}).promise();
+            describedStacks = await cfnClient.describeStacks({ StackName: 'my-scenario-stack-parameters' }).promise();
+            describedStacksFromInclude = await cfnClient.describeStacks({ StackName: 'something-else-scenario-stack-parameters' }).promise();
+            describedStacksFromInclude2 = await cfnClient.describeStacks({ StackName: 'something-different-scenario-stack-parameters' }).promise();
+            describedStacksFromInclude3 = await cfnClient.describeStacks({ StackName: 'something-with-pseudo-param-scenario-stack-parameters' }).promise();
 
-            await PerformTasksCommand.Perform({...command, tasksFile: basePathForScenario + '1-task-file-with-parameters.yml', parameters: 'includeMasterAccount=false' });
-            describedStacksAfterCleanup = await cfnClient.listStacks({StackStatusFilter: ['CREATE_COMPLETE', 'UPDATE_COMPLETE']}).promise();
-        } catch(err) {
+            await PerformTasksCommand.Perform({ ...command, tasksFile: basePathForScenario + '1-task-file-with-parameters.yml', parameters: 'includeMasterAccount=false partition=aws' });
+            describedStacksAfterCleanup = await cfnClient.listStacks({ StackStatusFilter: ['CREATE_COMPLETE', 'UPDATE_COMPLETE'] }).promise();
+        } catch (err) {
             expect(err.message).toBeUndefined();
         }
     });
-
     test('stack can be created using variable name and binding', () => {
         expect(describedStacks).toBeDefined();
     })
@@ -39,12 +48,21 @@ describe('when using parameters in template', () => {
         expect(describedStacksFromInclude).toBeDefined();
     })
 
+    test('parameters can be passed down to included template from perform-tasks option', () => {
+        expect(describedStacksFromInclude2).toBeDefined();
+    })
+
+
+    test('pseudo parameters can be used in included template', () => {
+        expect(describedStacksFromInclude3).toBeDefined();
+    })
+
     test('stack can be removed using variable binding and passing parameters', () => {
-        let summary = describedStacksAfterCleanup.StackSummaries.find(x=>x.StackName.endsWith('scenario-stack-parameters'));
+        let summary = describedStacksAfterCleanup.StackSummaries.find(x => x.StackName.endsWith('scenario-stack-parameters'));
         expect(summary).toBeUndefined();
     })
 
-    afterAll(async ()=> {
+    afterAll(async () => {
         await baseAfterAll(context);
     });
 });


### PR DESCRIPTION
adds support for pseudo parameter "AWS::Partition" to task files.

example 
``` yaml
Mappings:
  Partition:
    BindingRegions:
      aws: eu-west-1
      aws-us-gov: us-gov-west-1

BucketTemplate:
  Type: update-stacks
  Template: ./bucket.yml
  StackName: !Sub ${stackPrefix}-scenario-stack-parameters
  DefaultOrganizationBindingRegion: !FindInMap [ Partition, BindingRegions, !Ref AWS::Partition ]
  DefaultOrganizationBinding:
    IncludeMasterAccount: true
 ```