### PR TITLE
Tag values with ': ' break the yaml writer

### DIFF
--- a/src/writer/default-template-writer.ts
+++ b/src/writer/default-template-writer.ts
@@ -421,6 +421,10 @@ class Line implements YamlLine {
         if ('0987654321'.includes(val[0])) {
             val = '\'' + val + '\'';
         }
+        if (val.includes(': ')) {
+            val = '\'' + val + '\'';
+        }
+
         const indentation = ''.padStart(this.indentation, ' ');
         const line = `${indentation}${this.label}: ${val}`;
         return line.trimRight() + '\n';


### PR DESCRIPTION
An account tag with a value that includes a colon followed by a space breaks the yaml parser.
Correctly quote these values on generation.