### PR TITLE
Fix bug with provided TaskRoleName and large templates

### DIFF
--- a/src/util/aws-util.ts
+++ b/src/util/aws-util.ts
@@ -423,7 +423,7 @@ export class CfnUtil {
 
     public static async UploadTemplateToS3IfTooLarge(stackInput: CreateStackInput | UpdateStackInput | ValidateTemplateInput, binding: ICfnBinding, stackName: string, templateHash: string): Promise<void> {
         if (stackInput.TemplateBody && stackInput.TemplateBody.length > 50000) {
-            const s3Service = await AwsUtil.GetS3Service(binding.accountId, binding.region);
+            const s3Service = await AwsUtil.GetS3Service(binding.accountId, binding.region, binding.customRoleName);
             const bucketName = `org-formation-${binding.accountId}-${binding.region}-large-templates`;
             try {
                 await s3Service.createBucket({ Bucket: bucketName }).promise();


### PR DESCRIPTION
We use TaskRoleName to safely run perform-tasks locally. However, we've found that if the template is large, org-formation-cli attempts to assume the default OrganizationBuildRole. I traced it to this bug where an optional argument was not given when it actually should be given.