### PR TITLE
fix org file templating, add print-org command

### DIFF
--- a/cli-program.ts
+++ b/cli-program.ts
@@ -7,6 +7,7 @@ import {
     InitOrganizationCommand,
     InitPipelineCommand,
     PerformTasksCommand,
+    PrintOrganizationCommand,
     PrintStacksCommand,
     UpdateOrganizationCommand,
     UpdateStacksCommand,
@@ -49,6 +50,7 @@ export class CliProgram {
         new InitPipelineCommand(this.program);
         new InitOrganizationCommand(this.program);
         new PerformTasksCommand(this.program);
+        new PrintOrganizationCommand(this.program);
         new PrintTasksCommand(this.program);
         new PrintStacksCommand(this.program);
         new UpdateOrganizationCommand(this.program);

--- a/src/build-tasks/tasks/organization-task.ts
+++ b/src/build-tasks/tasks/organization-task.ts
@@ -43,7 +43,7 @@ export abstract class BaseOrganizationTask implements IBuildTask {
         updateCommand.templateFile = this.templatePath;
         updateCommand.forceDeploy = this.forceDeploy;
         updateCommand.taskRoleName = this.taskRoleName;
-        updateCommand.templatingContext = this.templatingContext;
+        updateCommand.TemplatingContext = this.templatingContext;
 
         await this.innerPerform(updateCommand);
     }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -6,6 +6,7 @@ export * from './execute-organization-changeset';
 export * from './init-organization-pipeline';
 export * from './init-organization';
 export * from './perform-tasks';
+export * from './print-org';
 export * from './print-stacks';
 export * from './update-organization';
 export * from './update-stacks';

--- a/src/commands/print-org.ts
+++ b/src/commands/print-org.ts
@@ -1,0 +1,45 @@
+import { Command } from 'commander';
+import { ConsoleUtil } from '../util/console-util';
+import { BaseCliCommand, ICommandArgs } from './base-command';
+import { TemplateRoot } from '~parser/parser';
+import { yamlDump } from '~yaml-cfn/index';
+
+
+const commandName = 'print-org <templateFile>';
+const commandDescription = 'outputs organization template file';
+
+export class PrintOrganizationCommand extends BaseCliCommand<IPrintOrganizationCommandArgs> {
+
+    public static async Perform(command: IPrintOrganizationCommandArgs): Promise<void> {
+        const x = new PrintOrganizationCommand();
+        await x.performCommand(command);
+    }
+
+    constructor(command?: Command) {
+        super(command, commandName, commandDescription, 'templateFile');
+    }
+
+    public addOptions(command: Command): void {
+        command.option('--debug-templating [debug-templating]', 'when set to true the output of text templating processes will be stored on disk', false);
+        command.option('--output <output>', 'the serialization format used when printing stacks. Either json or yaml.', 'yaml');
+        super.addOptions(command);
+    }
+
+    public async performCommand(command: IPrintOrganizationCommandArgs): Promise<void> {
+
+        const template = await TemplateRoot.create(command.templateFile, { TemplatingContext: command.TemplatingContext });
+
+        if (command.output === 'json') {
+            ConsoleUtil.Out(template.source);
+        } else {
+            ConsoleUtil.Out(yamlDump(template.contents));
+        }
+    }
+}
+
+export interface IPrintOrganizationCommandArgs extends ICommandArgs {
+    templateFile: string;
+    TemplatingContext?: {};
+    debugTemplating?: boolean;
+    output?: 'json' | 'yaml';
+}

--- a/src/commands/update-organization.ts
+++ b/src/commands/update-organization.ts
@@ -32,13 +32,14 @@ export class UpdateOrganizationCommand extends BaseCliCommand<IUpdateOrganizatio
     }
 
     public addOptions(command: Command): void {
+        command.option('--debug-templating [debug-templating]', 'when set to true the output of text templating processes will be stored on disk', false);
         super.addOptions(command);
     }
 
     public async performCommand(command: IUpdateOrganizationCommandArgs): Promise<void> {
 
 
-        const template = await TemplateRoot.create(command.templateFile, { TemplatingContext: command.templatingContext });
+        const template = await TemplateRoot.create(command.templateFile, { TemplatingContext: command.TemplatingContext });
         const state = await this.getState(command);
         let partitionProvider: S3StorageProvider;
 
@@ -46,8 +47,8 @@ export class UpdateOrganizationCommand extends BaseCliCommand<IUpdateOrganizatio
          * These additional providers and such are all over the place, since I added them as I went along.
          * Would be great if we could centralize the Partition provider stuff.
          */
-         const creds = await AwsUtil.GetPartitionCredentials();
-         if (creds) {
+        const creds = await AwsUtil.GetPartitionCredentials();
+        if (creds) {
             const masterAccountId = await AwsUtil.GetPartitionMasterAccountId();
             partitionProvider = await this.createOrGetStateBucket(command, AwsUtil.GetPartitionRegion(), masterAccountId, creds);
         }
@@ -97,5 +98,6 @@ export interface IUpdateOrganizationCommandArgs extends ICommandArgs {
     templateFile: string;
     forceDeploy?: boolean;
     taskRoleName?: string;
-    templatingContext?: {};
+    TemplatingContext?: {};
+    debugTemplating?: boolean;
 }

--- a/src/commands/validate-organization.ts
+++ b/src/commands/validate-organization.ts
@@ -25,7 +25,7 @@ export class ValidateOrganizationCommand extends BaseCliCommand<IUpdateOrganizat
 
     protected async performCommand(command: IUpdateOrganizationCommandArgs): Promise<void> {
 
-        const template = await TemplateRoot.create(command.templateFile, { TemplatingContext: command.templatingContext, OrganizationFileContents: (command as IUpdateStacksCommandArgs).organizationFileContents }, (command as IUpdateStacksCommandArgs).organizationFileHash);
+        const template = await TemplateRoot.create(command.templateFile, { TemplatingContext: command.TemplatingContext, OrganizationFileContents: (command as IUpdateStacksCommandArgs).organizationFileContents }, (command as IUpdateStacksCommandArgs).organizationFileHash);
         const state = await this.getState(command);
         const templateHash = template.hash;
 

--- a/test/unit-tests/commands/print-org.test.ts
+++ b/test/unit-tests/commands/print-org.test.ts
@@ -1,0 +1,33 @@
+import { Command, Option } from "commander";
+import { PrintOrganizationCommand } from "~commands/print-org";
+
+describe('when creating print tasks command', () => {
+    let command: PrintOrganizationCommand;
+    let commanderCommand: Command;
+    let subCommanderCommand: Command;
+
+    beforeEach(() => {
+        commanderCommand = new Command('root');
+        command = new PrintOrganizationCommand(commanderCommand);
+        subCommanderCommand = commanderCommand.commands[0];
+    });
+
+    test('print org command is created', () => {
+        expect(command).toBeDefined();
+        expect(subCommanderCommand).toBeDefined();
+        expect(subCommanderCommand.name()).toBe('print-org');
+    });
+
+    test('print org command has description', () => {
+        expect(subCommanderCommand).toBeDefined();
+        expect(subCommanderCommand.description()).toBeDefined();
+    });
+
+    test('command has required output parameter with default', () => {
+        const opts: Option[] = subCommanderCommand.options;
+        const stackNameOpt = opts.find((x) => x.long === '--output');
+        expect(stackNameOpt).toBeDefined();
+        expect(stackNameOpt.required).toBeTruthy();
+        expect(subCommanderCommand.output).toBe('yaml');
+    });
+});


### PR DESCRIPTION
Fixed typo which prevented organization file from using templateContext reported by me: #339 

Also added a `print-org` command, which just generates the organization template and outputs to console as either yaml or json so I can develop a good nunjucks template without using the `update` command. Added a simple print-org test as well.