### PR TITLE
fix email already exists error on partition accounts

### DIFF
--- a/src/aws-provider/aws-organization-writer.ts
+++ b/src/aws-provider/aws-organization-writer.ts
@@ -343,7 +343,7 @@ export class AwsOrganizationWriter {
 
     public async createPartitionAccount(resource: AccountResource, partitionWriter: AwsOrganizationWriter): Promise<PartitionCreateResponse> {
 
-        const account: AWSAccount = [...this.organization.accounts, this.organization.masterAccount].find(x => x.Id === resource.accountId);
+        const account: AWSAccount = [...this.organization.accounts, this.organization.masterAccount].find(x => x.Id === resource.accountId || x.Email === resource.rootEmail);
         if (account !== undefined) {
             const partitionAccount = (await partitionWriter._listAccounts()).find(x => x.Email === account.Email);
             await this.updateAccount(resource, account.Id);


### PR DESCRIPTION
fix issue where PartitionAccountId and AccountId is required in organization file or it tries to recreate the partition and fails due to EMAIL_ALREADY_EXISTS error