### PR TITLE
make Fn::EnumTargetAccounts more useful

### DIFF
--- a/docs/cloudformation-resources.md
+++ b/docs/cloudformation-resources.md
@@ -339,10 +339,28 @@ Principal:
 
 - The Sub expression can have single quotes
 - The Sub expression may also contain other Sub expression constructs (such as Ref to parameter)
-- For `Fn::EnumTargetAccounts` use the pre-defined variable `${account}` in the Sub expression
+- For `Fn::EnumTargetAccounts` use one of the pre-defined variables `${account}`, `${AccountId}`, `${AccountName}`, `${LogicalId}`, `${RootEmail}`, `${Alias}`, `${Tags.TAGNAME}` anywhere in the Sub expression
+- If an account does not have the specified Tag or no Alias is defined, the expression will return variables as `${Tags.TAGNAME} or ${Alias}` literally.
 - For `Fn::EnumTargetRegions` use the pre-defined variable `${region}` in the Sub expression
 - When placed inside an array the output of `Fn::EnumTargetAccounts` and `Fn::EnumTargetRegions` will be inserted into the array.
 
+Multiple variables may be used in the same Sub expression.
+``` yaml
+Principal:
+  AWS: Fn::EnumTargetAccounts MyBinding ${AccountId}:${RootEmail}:${Tags.subdomain}
+
+ ```
+
+ Will result in the following CloudFormation (assuming MyBinding has 3 accounts):
+
+``` yaml
+Principal:
+  AWS:
+    - 111111111111:account+01@example.com:mysubdomain1
+    - 222222222222:account+02@example.com:mysubdomain2
+    - 333333333333:account+03@example.com:mysubdomain3
+
+ ```
 
 ### Fn::TargetCount
 `Fn::TargetCount` will return the number of targets for a binding (regions * accounts).

--- a/src/build-tasks/tasks/update-stacks-task.ts
+++ b/src/build-tasks/tasks/update-stacks-task.ts
@@ -112,7 +112,6 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
             stackName: config.StackName,
             templateFile: templatePath,
         };
-
         if (config.StackDescription) {
             args.stackDescription = config.StackDescription;
         }

--- a/src/build-tasks/tasks/update-stacks-task.ts
+++ b/src/build-tasks/tasks/update-stacks-task.ts
@@ -27,7 +27,8 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
             concurrencyForCleanup: config.MaxConcurrentStacks,
             isDependency: BuildTaskProvider.createIsDependency(config),
             perform: async (): Promise<void> => {
-                const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command, resolver);
+                const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command);
+                updateStacksCommand.resolver = resolver;
                 ConsoleUtil.LogInfo(`Executing: ${config.Type} ${updateStacksCommand.templateFile} ${updateStacksCommand.stackName}.`);
                 await UpdateStacksCommand.Perform(updateStacksCommand);
             },
@@ -44,7 +45,8 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
             StackName: config.StackName,
             isDependency: BuildTaskProvider.createIsDependency(config),
             perform: async (): Promise<void> => {
-                const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command, resolver);
+                const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command);
+                updateStacksCommand.resolver = resolver;
                 await ValidateStacksCommand.Perform(updateStacksCommand);
             },
         };
@@ -59,7 +61,8 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
             StackName: config.StackName,
             isDependency: BuildTaskProvider.createIsDependency(config),
             perform: async (): Promise<void> => {
-                const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command, resolver);
+                const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command);
+                updateStacksCommand.resolver = resolver;
                 await PrintStacksCommand.Perform({ ...updateStacksCommand, stackName: config.StackName });
             },
         };
@@ -95,7 +98,7 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
         };
     }
 
-    static createUpdateStacksCommandArgs(config: IUpdateStackTaskConfiguration, command: IPerformTasksCommandArgs, resolver: CfnExpressionResolver): IUpdateStacksCommandArgs {
+    static createUpdateStacksCommandArgs(config: IUpdateStackTaskConfiguration, command: IPerformTasksCommandArgs): IUpdateStacksCommandArgs {
 
         let templatePath = config.Template;
 
@@ -110,8 +113,6 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
             templateFile: templatePath,
         };
 
-        args.resolver = resolver;
-
         if (config.StackDescription) {
             args.stackDescription = config.StackDescription;
         }
@@ -123,7 +124,7 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
         }
 
         if (config.TemplatingContext) {
-            args.templatingContext = resolver.resolveTemplatingContext(config.TemplatingContext);
+            args.templatingContext = config.TemplatingContext;
         } else {
             args.templatingContext = undefined;
         }

--- a/src/build-tasks/tasks/update-stacks-task.ts
+++ b/src/build-tasks/tasks/update-stacks-task.ts
@@ -27,8 +27,7 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
             concurrencyForCleanup: config.MaxConcurrentStacks,
             isDependency: BuildTaskProvider.createIsDependency(config),
             perform: async (): Promise<void> => {
-                const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command);
-                updateStacksCommand.resolver = resolver;
+                const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command, resolver);
                 ConsoleUtil.LogInfo(`Executing: ${config.Type} ${updateStacksCommand.templateFile} ${updateStacksCommand.stackName}.`);
                 await UpdateStacksCommand.Perform(updateStacksCommand);
             },
@@ -45,8 +44,7 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
             StackName: config.StackName,
             isDependency: BuildTaskProvider.createIsDependency(config),
             perform: async (): Promise<void> => {
-                const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command);
-                updateStacksCommand.resolver = resolver;
+                const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command, resolver);
                 await ValidateStacksCommand.Perform(updateStacksCommand);
             },
         };
@@ -61,8 +59,7 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
             StackName: config.StackName,
             isDependency: BuildTaskProvider.createIsDependency(config),
             perform: async (): Promise<void> => {
-                const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command);
-                updateStacksCommand.resolver = resolver;
+                const updateStacksCommand = UpdateStacksBuildTaskProvider.createUpdateStacksCommandArgs(config, command, resolver);
                 await PrintStacksCommand.Perform({ ...updateStacksCommand, stackName: config.StackName });
             },
         };
@@ -98,7 +95,7 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
         };
     }
 
-    static createUpdateStacksCommandArgs(config: IUpdateStackTaskConfiguration, command: IPerformTasksCommandArgs): IUpdateStacksCommandArgs {
+    static createUpdateStacksCommandArgs(config: IUpdateStackTaskConfiguration, command: IPerformTasksCommandArgs, resolver: CfnExpressionResolver): IUpdateStacksCommandArgs {
 
         let templatePath = config.Template;
 
@@ -112,6 +109,9 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
             stackName: config.StackName,
             templateFile: templatePath,
         };
+
+        args.resolver = resolver;
+
         if (config.StackDescription) {
             args.stackDescription = config.StackDescription;
         }
@@ -123,7 +123,7 @@ export class UpdateStacksBuildTaskProvider implements IBuildTaskProvider<IUpdate
         }
 
         if (config.TemplatingContext) {
-            args.templatingContext = config.TemplatingContext;
+            args.templatingContext = resolver.resolveTemplatingContext(config.TemplatingContext);
         } else {
             args.templatingContext = undefined;
         }

--- a/src/cfn-binder/cfn-binder.ts
+++ b/src/cfn-binder/cfn-binder.ts
@@ -137,7 +137,8 @@ export class CloudFormationBinder {
                 if (!dependsOnAccountBinding) {
                     throw new OrgFormationError(`unable to find account with logical Id ${dependsOnLogicalAccount}`);
                 }
-                binding.accountDependencies.push(dependsOnAccountBinding.physicalId);
+                const physicalId = (this.partition && dependsOnAccountBinding.partitionId) ? dependsOnAccountBinding.partitionId : dependsOnAccountBinding.physicalId;
+                binding.accountDependencies.push(physicalId);
             }
             /* end move elsewhere */
 

--- a/test/resources/enum-expressions/enum-expressions.yml
+++ b/test/resources/enum-expressions/enum-expressions.yml
@@ -110,3 +110,11 @@ Resources:
       - '3'
       - Fn::EnumTargetAccounts Account2Binding 'blabla ${account} blabla'
       - '5'
+
+  Resource3:
+    Type: AWS::SNS::Topic
+    OrganizationBinding:
+      Region: eu-west-1
+      IncludeMasterAccount: true
+    Properties:
+      EnumAllTargetAccounts: Fn::EnumTargetAccounts AllAccountsBinding blabla-${AccountId}-${LogicalId}-${AccountName}-${Alias}-${RootEmail}-${Tags.subdomain}-blabla

--- a/test/resources/enum-expressions/organization.yml
+++ b/test/resources/enum-expressions/organization.yml
@@ -11,6 +11,7 @@ Organization:
     Properties:
       AccountId: '000000000000'
       AccountName: 'master account'
+      Alias: 'MasterAlias'
       RootEmail: 'root@mail.com'
 
   Account1:
@@ -18,6 +19,7 @@ Organization:
     Properties:
       RootEmail: acc1@my.org
       AccountName: Account1
+      Alias: Account1Alias
       Tags:
         subdomain: acc1
 
@@ -26,6 +28,7 @@ Organization:
     Properties:
       RootEmail: acc2@my.org
       AccountName: Account2
+      Alias: Account2Alias
       Tags:
         subdomain: acc2
 
@@ -35,16 +38,17 @@ Organization:
     Properties:
       RootEmail: acc3@my.org
       AccountName: Account3
+      Alias: Account3Alias
       Tags:
-        subdomain: acc2
+        nosubdomain: acc3
 
   Account4:
     Type: OC::ORG::Account
     Properties:
       RootEmail: acc4@my.org
       AccountName: Account4
-      Tags:
-        subdomain: acc2
+      # Alias: Account4Alias
+
 
   #============================================#
   # Organizational Units

--- a/test/unit-tests/templates/enum-expressions.test.ts
+++ b/test/unit-tests/templates/enum-expressions.test.ts
@@ -176,5 +176,21 @@ describe('when resolving enum-expressions', () => {
         expect(val[4]).toBe('5');
     });
 
+    test('enum target for all accounts creates array with all values for all accounts', () => {
+        const resource = masterAccountTemplate.Resources.Resource3;
+        const val = resource.Properties.EnumAllTargetAccounts;
+        expect(Array.isArray(val)).toBe(true);
+        expect(val.length).toBe(4);
+        expect(val[0]).toBe('blabla-111111111111-Account1-Account1-Account1Alias-acc1@my.org-acc1-blabla');
+        expect(val[1]).toBe('blabla-222222222222-Account2-Account2-Account2Alias-acc2@my.org-acc2-blabla');
+    });
 
+    test('enum accounts for results in Sub expression if missing Tags', () => {
+        const resource = masterAccountTemplate.Resources.Resource3;
+        const val = resource.Properties.EnumAllTargetAccounts;
+        expect(val[2]['Fn::Sub']).toBeDefined();
+        expect(val[3]['Fn::Sub']).toBeDefined();
+        expect(val[2]['Fn::Sub']).toBe('blabla-333333333333-Account3-Account3-Account3Alias-acc3@my.org-${Tags.subdomain}-blabla');
+        expect(val[3]['Fn::Sub']).toBe('blabla-444444444444-Account4-Account4-${Alias}-acc4@my.org-${Tags.subdomain}-blabla');
+    });
 });


### PR DESCRIPTION
COMPLETED:
- make `Fn::EnumTargetAccounts` more useful in CloudFormation Templates
  - Add AccountId parameter
  - Add LogicalId parameter
  - Add AccountName parameter
  - Add Alias parameter
  - Add RootEmail parameter
  - Add Tags parameter (the value here will be replaced if it matches a Tag Key on the account)
- resolve `Fn::EnumTargetAccounts` in TemplatingContext on stack-updates tasks
- Add new tests
- Fix old tests
- Test Partition
- Update documentation

-------------------------------

Updates to CloudFormation Template Expression Resolving
```yaml
EnumAccountsExpression:
    Type: Custom::EnumAccountsExpressionTest
    Properties:
      accounts: Fn::EnumTargetAccounts AllAccountsBinding ${account} # backwards compatibility
      AccountIds: Fn::EnumTargetAccounts AllAccountsBinding ${AccountId}
      LogicalIds: Fn::EnumTargetAccounts AllAccountsBinding ${LogicalId}
      AccountNames: Fn::EnumTargetAccounts AllAccountsBinding ${AccountName}
      Aliases: Fn::EnumTargetAccounts AllAccountsBinding ${Alias}
      RootEmails: Fn::EnumTargetAccounts AllAccountsBinding ${RootEmail}
      Tags: Fn::EnumTargetAccounts AllAccountsBinding ${Tags.MyAccountTagKey}
```

CloudFormation Template Expression Resolving - Output
```yaml
EnumAccountsExpression:
    Type: Custom::EnumAccountsExpressionTest
    Properties:
      accounts:
         - '111111111111'
         - '222222222222'
         - '333333333333'
         - '444444444444'
       AccountIds:
         - '111111111111'
         - '222222222222'
         - '333333333333'
         - '444444444444'
       LogicalIds:
         - Account01
         - Account02
         - Account03
         - Account04
       AccountNames:
         - account-name-01
         - account-name-02
         - account-name-03
         - account-name-04
       Aliases:
         - account-alias-01
         - account-alias-02
         - account-alias-03
         - ${Alias} # if alias does not exist, the expression returns unresolved
       RootEmails:
         - account+01@trek10.com
         - account+02@trek10.com
         - account+03@trek10.com
         - account+04@trek10.com
       Tags:
         - MyAccountTagValue
         - MyAccountTagValue
         - MyAccountTagValue
         - ${Tags.MyAccountTagKey} # if tag does not exist, the expression returns unresolved
```
---------------------------------
Multiple Values in Expressions
```yaml
EnumAccountsExpression:
    Type: Custom::EnumAccountsExpressionTest
    Properties:
      AccountEmailMapping: Fn::EnumTargetAccounts AllAccountsBinding ${AccountId}:${RootEmail}
```
Multiple Values in Expressions - Output
```yaml
EnumAccountsExpression:
    Type: Custom::EnumAccountsExpressionTest
    Properties:
      accounts:
         - 111111111111:account+01@trek10.com
         - 222222222222:account+02@trek10.com
         - 333333333333:account+03@trek10.com
         - 444444444444:account+04@trek10.com
```
-------------------------------------
Notes:
- `Fn::EnumTargetRegions` should work the same and only allows for the ${region} parameter