### PR TITLE
Support comma-delimited CloudFormation parameter values

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,22 +10,22 @@ If you choose to pass a `build-account-id` option, you will need to have created
 
 Typing ``help`` after any command in the commandline will print documentation.
 
-- [org-formation cli reference](#org-formation-cli-reference)
+- [``org-formation`` cli reference](#org-formation-clireference)
   - [Operations on organization resources](#operations-on-organization-resources)
-    - [org-formation init](#org-formation-init)
-    - [org-formation init-pipeline](#org-formation-init-pipeline)
-    - [org-formation update](#org-formation-update)
-    - [org-formation create-change-set](#org-formation-create-change-set)
-    - [org-formation execute-change-set](#org-formation-execute-change-set)
+    - [``org-formation init``](#org-formation-init)
+    - [``org-formation init-pipeline``](#org-formation-init-pipeline)
+    - [``org-formation update``](#org-formation-update)
+    - [``org-formation create-change-set``](#org-formation-create-change-set)
+    - [``org-formation execute-change-set``](#org-formation-execute-change-set)
   - [Operations on stacks](#operations-on-stacks)
-    - [org-formation update-stacks](#org-formation-update-stacks)
-    - [org-formation validate-stacks](#org-formation-validate-stacks)
-    - [org-formation print-stacks](#org-formation-print-stacks)
-    - [org-formation describe-stacks](#org-formation-describe-stacks)
-    - [org-formation delete-stacks](#org-formation-delete-stacks)
+    - [``org-formation update-stacks``](#org-formation-update-stacks)
+    - [``org-formation validate-stacks``](#org-formation-validate-stacks)
+    - [``org-formation print-stacks``](#org-formation-print-stacks)
+    - [``org-formation describe-stacks``](#org-formation-describe-stacks)
+    - [``org-formation delete-stacks``](#org-formation-delete-stacks)
   - [Operations on task files](#operations-on-task-files)
-    - [org-formation perform-tasks](#org-formation-perform-tasks)
-    - [org-formation validate-tasks](#org-formation-validate-tasks)
+    - [``org-formation perform-tasks``](#org-formation-perform-tasks)
+    - [``org-formation validate-tasks``](#org-formation-validate-tasks)
   - [Global options](#global-options)
   - [Runtime configuration (.org-formationrc)](#runtime-configuration-org-formationrc)
 
@@ -116,6 +116,11 @@ parameters can be passed in a similar fashion CloudFormation parameters are pass
 or the somewhat more simple fashion:
 ``> org-formation update-stacks template.yml --stack-name my-stack --parameters Param1=Val1 Param2=Val2``
 
+Comma-delimited lists can be passed either by escaping the commas:
+``> org-formation update-stacks template.yml --stack-name my-stack --parameters ParameterKey=MyRegions,ParameterValue=eu-west-1\,us-east-2``
+
+or by using quotes (`"`) around the parameter value:
+``> org-formation update-stacks template.yml --stack-name my-stack --parameters ParameterKey=MyRegions,ParameterValue="eu-west-1,us-east-2"``
 
 ### ``org-formation validate-stacks``
 

--- a/test/unit-tests/core/cfn-parameters.test.ts
+++ b/test/unit-tests/core/cfn-parameters.test.ts
@@ -1,0 +1,50 @@
+import { CfnParameters } from '~core/cfn-parameters';
+
+describe('when processing stack parameters', () => {
+  test('string parameters create an object', () => {
+    const commandParameters = 'ParameterKey=foo,ParameterValue=bar ParameterKey=foo2,ParameterValue=bar2';
+    const expected = { foo: 'bar', 'foo2': 'bar2' }
+    const parsed = CfnParameters.ParseParameterValues(commandParameters)
+    expect(parsed).toStrictEqual(expected)
+  });
+
+  test('string parameters create an object', () => {
+    const commandParameters = 'ParameterKey=foo,ParameterValue=bar ParameterKey=foo2,ParameterValue=bar2';
+    const expected = { foo: 'bar', 'foo2': 'bar2' }
+    const parsed = CfnParameters.ParseParameterValues(commandParameters)
+    expect(parsed).toStrictEqual(expected)
+  });
+
+  test('comma-delimited lists are parsed with comma escaping', () => {
+    const commandParameters = 'ParameterKey=foo,ParameterValue=one\\,two ParameterKey=foo2,ParameterValue=bar2';
+    const expected = { foo: 'one,two', 'foo2': 'bar2' }
+    const parsed = CfnParameters.ParseParameterValues(commandParameters)
+    expect(parsed).toStrictEqual(expected)
+  });
+
+  test('comma-delimited lists are parsed with quoting', () => {
+    const commandParameters = 'ParameterKey=foo,ParameterValue="one,two" ParameterKey=foo2,ParameterValue="three,four"';
+    const expected = { foo: 'one,two', 'foo2': 'three,four' }
+    const parsed = CfnParameters.ParseParameterValues(commandParameters)
+    expect(parsed).toStrictEqual(expected)
+  });
+
+  test('empty strings are handled', () => {
+    const commandParameters = '';
+    const expected = {}
+    const parsed = CfnParameters.ParseParameterValues(commandParameters)
+    expect(parsed).toStrictEqual(expected)
+  });
+
+  test('undefined parameters are handled', () => {
+    const parsed = CfnParameters.ParseParameterValues(undefined)
+    expect(parsed).toStrictEqual({})
+  });
+
+  test('key=value syntax is supported', () => {
+    const commandParameters = 'foo=bar foo2=bar2';
+    const expected = { foo: 'bar', foo2: 'bar2' };
+    const parsed = CfnParameters.ParseParameterValues(commandParameters);
+    expect(parsed).toStrictEqual(expected);
+  })
+});

--- a/test/unit-tests/core/cfn-parameters.test.ts
+++ b/test/unit-tests/core/cfn-parameters.test.ts
@@ -29,6 +29,13 @@ describe('when processing stack parameters', () => {
     expect(parsed).toStrictEqual(expected)
   });
 
+  test('comma-delimited lists are parsed with mixed quoting and escaping', () => {
+    const commandParameters = 'ParameterKey=a,ParameterValue="A1,A2" ParameterKey=b,ParameterValue=B1\,B2 ParameterKey=c,ParameterValue=C1\,C2';
+    const expected = { a: 'A1,A2', b: 'B1,B2', c: 'C1,C2' }
+    const parsed = CfnParameters.ParseParameterValues(commandParameters)
+    expect(parsed).toStrictEqual(expected)
+  });
+
   test('empty strings are handled', () => {
     const commandParameters = '';
     const expected = {}
@@ -46,5 +53,15 @@ describe('when processing stack parameters', () => {
     const expected = { foo: 'bar', foo2: 'bar2' };
     const parsed = CfnParameters.ParseParameterValues(commandParameters);
     expect(parsed).toStrictEqual(expected);
+  })
+
+  test('invalid syntax throws an error', () => {
+    const commandParameters = 'foo-bar';
+    expect(() => CfnParameters.ParseParameterValues(commandParameters)).toThrowError()
+  })
+
+  test('key=value syntax with multiple equals signs throws an error', () => {
+    const commandParameters = 'foo=bar=bar2';
+    expect(() => CfnParameters.ParseParameterValues(commandParameters)).toThrowError()
   })
 });


### PR DESCRIPTION
With the AWS CLI, it is possible to provide comma-delimited parameter values to `cloudformation update-stack`/`create-stack` using either of the following formats:

1. `--parameters ParameterKey=foo,ParameterValue=one\,two`
2. `--parameters ParameterKey=foo,ParameterValue="one,two"`

The current org-formation parser splits on commas and discards the `two` part above as a result.

I was attempting to use this syntax in the `update-stacks` command to pass the supported AWS regions as a [`CommaDelimitedList`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html) property, i.e., `--parameters ParameterKey=SupportedRegions,ParameterValue=eu-west-1\,eu-west-2\,eu-central-1` but observed that only the first region was being passed and included the trailing `\`.

- This change attempts to implement the same syntax as supported in the AWS CLI without the complexity of the AWS CLI's parser (https://github.com/aws/aws-cli/blob/9c6d0dca63671e39e0368054ec6a4090320ff158/awscli/shorthand.py#L221)
- The new unit tests in this PR replicate the cases in the AWS CLI unit tests: https://github.com/aws/aws-cli/blob/45b0063b2d0b245b17a57fd9eebd9fcc87c4426a/tests/functional/cloudformation/test_create_stack.py#L39
There may be other cases that I haven't considered here, but I'm happy to amend the solution as advised.
