### PR TITLE
fix: ensure printing and validation only skipped when accounts are added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to aws organization formation will be documented in this fil
 **BREAKING CHANGES**:
 - v1.0.0: execution role under which org-formation is ran requires the ec2:describeRegions permission 
 
+**unreleased**
+- fix: only prevent printing/ validating stacks if an account is added to organization.yml (not prevent printing if an OU got added)
+
 **version 1.0.4**
 - feat: allow `Fn::EnumTargetAccounts` to be used in combination with `${AccountId}`, `${AccountName}`, `${LogicalId}`, `${RootEmail}`, `${Alias}`, `${Tags.TAGNAME}`
 - feat: dependsOnAccount support for govcloud

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-organization-formation",
-  "version": "1.0.4",
+  "version": "1.0.5-beta.1",
   "description": "Infrastructure as code solution for AWS Organizations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/commands/validate-organization.ts
+++ b/src/commands/validate-organization.ts
@@ -5,6 +5,7 @@ import { IUpdateOrganizationCommandArgs } from './update-organization';
 import { IUpdateStacksCommandArgs } from './update-stacks';
 import { TemplateRoot } from '~parser/parser';
 import { GlobalState } from '~util/global-state';
+import { OrgResourceTypes } from '~parser/model';
 
 
 const commandName = 'validate <templateFile>';
@@ -42,7 +43,7 @@ export class ValidateOrganizationCommand extends BaseCliCommand<IUpdateOrganizat
         const binder = await this.getOrganizationBinder(template, state);
 
         const tasks = binder.enumBuildTasks();
-        const createTasks = tasks.filter(x => x.action === 'Create');
+        const createTasks = tasks.filter(x => x.action === 'Create' && x.type === OrgResourceTypes.Account);
         if (createTasks.length > 0) {
             ConsoleUtil.LogWarning('Accounts were added to the organization model.');
             ConsoleUtil.LogWarning('Tasks might depend on updating the organization.');


### PR DESCRIPTION
currently, when an SCP or OU is added in the organization.yml file printing and validation is skipped. this however does only make sense if an account is added. 