### PR TITLE
fix: ensure pwd policy does not get deleted prior to update

### DIFF
--- a/src/aws-provider/aws-organization-writer.ts
+++ b/src/aws-provider/aws-organization-writer.ts
@@ -465,7 +465,7 @@ export class AwsOrganizationWriter {
         if (!passwordPolicyEquals(previousResource?.passwordPolicy, resource.passwordPolicy)) {
             const assumeRoleConfig = await GetOrganizationAccessRoleInTargetAccount(this.crossAccountConfig, accountId);
             const iam = await AwsUtil.GetIamService(accountId, assumeRoleConfig.role, assumeRoleConfig.viaRole, (account.Type === 'PartitionAccount'));
-            if (account.PasswordPolicy) {
+            if (account.PasswordPolicy && !resource.passwordPolicy.TemplateResource) {
                 try {
                     await iam.deleteAccountPasswordPolicy().promise();
                 } catch (err) {


### PR DESCRIPTION
This change ensures that there is no DeletAccountPasswordPolicy prior to updating the password policy.
