### PR TITLE
Task matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to aws organization formation will be documented in this fil
 - feat: specify bucket to be used for large template uploads (on validate-tasks, perform-tasks, validate-stacks and update-stacks)
 - feat: support closing removed accounts form the organization specifying "CloseAccountsOnRemoval: true" on the OrganizationRoot in organization.yml
 - fix: better defaults for the deploy-cdk task: added `--all --require-approval=never` to default deploy and destroy commands
+- fix: allow matching a single task using `--match` taking a globPattern (e.g. `--match '**/MyTask'`) or the exact name of a task.
 
 
 **version 1.0.4**

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -206,6 +206,7 @@ Will perform tasks from *tasksFile*.
 |<nobr>--max-concurrent-stacks</nobr> | 1 | Maximum number of stacks (within a task) to be executed concurrently |
 |<nobr>--failed-stacks-tolerance</nobr> | 0 | The number of failed stacks (within a task) after which execution stops|
 |<nobr>--large-template-bucket-name</nobr> | 0 | The name of the S3 bucket that should be used when uploading templates larger than 50_000 bytes |
+|<nobr>--match</nobr> | undefined | Matches a specific tasks using using a globPattern (e.g. `--match 'MyTask/**'`) or the exact name of a task.|
 
 
 Parameters can be passed using the following syntax:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-organization-formation",
-  "version": "1.0.5-beta.17",
+  "version": "1.0.5-beta.18",
   "description": "Infrastructure as code solution for AWS Organizations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/commands/perform-tasks.ts
+++ b/src/commands/perform-tasks.ts
@@ -45,7 +45,7 @@ export class PerformTasksCommand extends BaseCliCommand<IPerformTasksCommandArgs
         command.option('--organization-state-bucket-name [organization-state-bucket-name]', 'name of the bucket that contains the read-only organization state');
         command.option('--debug-templating [debug-templating]', 'when set to true the output of text templating processes will be stored on disk', false);
         command.option('--templating-context-file [templating-context-file]', 'json file used as context for nunjuck text templating of organization and tasks file');
-        command.option('--task-matchers [task-matchers]', 'glob patters used to define/filter which tasks to run.');
+        command.option('--task-matcher [task-matcher]', 'glob pattern used to define/filter which tasks to run.');
         command.option('--large-template-bucket-name [large-template-bucket-name]', 'bucket used when uploading large templates. default is to create a bucket just-in-time in the target account');
 
         command.option('--skip-storing-state', 'when set, the state will not be stored');
@@ -110,7 +110,6 @@ export class PerformTasksCommand extends BaseCliCommand<IPerformTasksCommandArgs
             if(isLeafTask) {
                 const isMatching = minimatch(taskFullName, taskMatcher);
                 skipTask = isMatching ? task.skip : true;
-                console.log(taskFullName, isMatching, task.skip);
             }
 
             if(isLeafTask === false && task.skip !== true) {
@@ -123,6 +122,11 @@ export class PerformTasksCommand extends BaseCliCommand<IPerformTasksCommandArgs
                 task.skip = true;
                 skippedLeaves = skippedLeaves + 1;
             }
+
+            if(isLeafTask && skipTask !== true) {
+                ConsoleUtil.LogInfo(`${taskFullName} matched the '${taskMatcher}' globPattern`);
+            }
+
         }
         return skippedLeaves;
     }

--- a/src/commands/perform-tasks.ts
+++ b/src/commands/perform-tasks.ts
@@ -109,13 +109,13 @@ export class PerformTasksCommand extends BaseCliCommand<IPerformTasksCommandArgs
 
             if(isLeafTask) {
                 const isMatching = minimatch(taskFullName, taskMatcher);
-                skipTask = isMatching ? task.skip : true;
+                skipTask = isMatching ? false : true;
             }
 
-            if(isLeafTask === false && task.skip !== true) {
+            if(isLeafTask === false) {
                 const skippedChildTasks = this.skipNonMatchingLeafTasks(task.childTasks, taskMatcher, `${taskFullName}/`);
                 const isAllSkipped = task.childTasks.length === skippedChildTasks;
-                task.skip = isAllSkipped ? true : task.skip;
+                task.skip = isAllSkipped ? true : false;
             }
 
             if (skipTask) {
@@ -124,6 +124,7 @@ export class PerformTasksCommand extends BaseCliCommand<IPerformTasksCommandArgs
             }
 
             if(isLeafTask && skipTask !== true) {
+                task.skip = false;
                 ConsoleUtil.LogInfo(`${taskFullName} matched the '${taskMatcher}' globPattern`);
             }
 

--- a/src/commands/perform-tasks.ts
+++ b/src/commands/perform-tasks.ts
@@ -74,7 +74,7 @@ export class PerformTasksCommand extends BaseCliCommand<IPerformTasksCommandArgs
         ConsoleUtil.state = state;
 
         if(command.taskMatcher) {
-            const tasksPrefix = '/';
+            const tasksPrefix = '';
             this.skipNonMatchingLeafTasks(tasks, command.taskMatcher, tasksPrefix);
         }
 

--- a/src/commands/perform-tasks.ts
+++ b/src/commands/perform-tasks.ts
@@ -74,8 +74,10 @@ export class PerformTasksCommand extends BaseCliCommand<IPerformTasksCommandArgs
         ConsoleUtil.state = state;
 
         if(command.match) {
-            const tasksPrefix = '';
-            this.skipNonMatchingLeafTasks(tasks, command.match, tasksPrefix);
+            const skippedTasks = this.skipNonMatchingLeafTasks(tasks, command.match, '');
+            if(skippedTasks === tasks.length) {
+                ConsoleUtil.LogWarning(`--match parameter ${command.match} did not match any tasks`);
+            }
         }
 
         state.performUpdateToVersion2IfNeeded();

--- a/src/commands/perform-tasks.ts
+++ b/src/commands/perform-tasks.ts
@@ -45,7 +45,7 @@ export class PerformTasksCommand extends BaseCliCommand<IPerformTasksCommandArgs
         command.option('--organization-state-bucket-name [organization-state-bucket-name]', 'name of the bucket that contains the read-only organization state');
         command.option('--debug-templating [debug-templating]', 'when set to true the output of text templating processes will be stored on disk', false);
         command.option('--templating-context-file [templating-context-file]', 'json file used as context for nunjuck text templating of organization and tasks file');
-        command.option('--task-matcher [task-matcher]', 'glob pattern used to define/filter which tasks to run.');
+        command.option('--match [match]', 'glob pattern used to define/filter which tasks to run.');
         command.option('--large-template-bucket-name [large-template-bucket-name]', 'bucket used when uploading large templates. default is to create a bucket just-in-time in the target account');
 
         command.option('--skip-storing-state', 'when set, the state will not be stored');
@@ -73,9 +73,9 @@ export class PerformTasksCommand extends BaseCliCommand<IPerformTasksCommandArgs
         const tasks = config.enumBuildTasks(command);
         ConsoleUtil.state = state;
 
-        if(command.taskMatcher) {
+        if(command.match) {
             const tasksPrefix = '';
-            this.skipNonMatchingLeafTasks(tasks, command.taskMatcher, tasksPrefix);
+            this.skipNonMatchingLeafTasks(tasks, command.match, tasksPrefix);
         }
 
         state.performUpdateToVersion2IfNeeded();
@@ -169,5 +169,5 @@ export interface IPerformTasksCommandArgs extends ICommandArgs {
     forceDeploy?: boolean;
     organizationObject?: any;
     skipStoringState?: true;
-    taskMatcher?: string;
+    match?: string;
 }

--- a/test/unit-tests/commands/perform-tasks.test.ts
+++ b/test/unit-tests/commands/perform-tasks.test.ts
@@ -375,34 +375,7 @@ describe("when running perform-tasks with taskMatchers", () => {
         }] as IBuildTask[];
         expect(buildRunnerRunTasksMock).toBeCalledWith(expectedTask, false, 1, 0);
     })
-    
-    test.each([
-        ["match","*",true],
-        ["match","match",true],
-        ["/match","*",false],
-        ["/match","match",false],
-        ["/dontMatch/","*",false],
-        ["/folder/match","*",false],
-        ["/folder/dontMatch/","*",false],
-        
-        ["/match","/*",true],
-        ["/dontMatch/","/*",true],
-        ["/folder/dontMatch/","/*",false],
-        ["/folder/dontMatch","/*",false],
-        
-        ["/folder/match","/*/**",true],
-        ["/folder/","/*/**",true],
-        
-        ["/folder/","/*/**/*.(js|ts)",false],
-        ["/folder/some.js","/*/**/*+(.js|.ts)",true],
-        ["/folder/some.ts","/*/**/*+(.js|.ts)",true],
-        ["/folder/some.ts.d","/*/**/*+(.js|.ts)",false],
-        
-    ])("Testing Minimatch: %s, %s, %s", (str, globMatcher, result) => {
-        expect(minimatch(str,globMatcher)).toBe(result)
-        
-    })
-    
+
     test.each([
         //globMatcher, [updateOrg, node1, leaf2, leaf11, leaf12], [updateOrg, node1, leaf2, leaf11, leaf12]],
         ["test", [,,,,], [,true,true,true,true]],
@@ -424,7 +397,7 @@ describe("when running perform-tasks with taskMatchers", () => {
         
         ["/updateOrg/**/*+(2|12)", [,,,,true], [,true,,true,true]], //checking that the top task is also skipped when no child is executed
         
-    ])("Task Matchers are present: %s", async (taskMatcher, skipTasks, skippedTasks) => {
+    ])("Task Matcher is present: %s", async (taskMatcher, skipTasks, skippedTasks) => {
         
         const [updateOrgSkip, nodeTask1Skip, leafTask2Skip, leafTask11Skip, leafTask12Skip] = skipTasks
         const tasks = [{

--- a/test/unit-tests/commands/perform-tasks.test.ts
+++ b/test/unit-tests/commands/perform-tasks.test.ts
@@ -379,23 +379,22 @@ describe("when running perform-tasks with taskMatchers", () => {
     test.each([
         //globMatcher, [updateOrg, node1, leaf2, leaf11, leaf12], [updateOrg, node1, leaf2, leaf11, leaf12]],
         ["test", [,,,,], [,true,true,true,true]],
-        ["/", [,,,,], [,true,true,true,true]],
-        ["/*", [,,,,], [,true,true,true,true]],
-        ["/*/*", [,,,,], [,true,,true,true]],
-        ["/*/**", [,,,,], [,,,,]],
-        ["/**", [,,,,], [,,,,]],
-        ["/updateOrg/**", [,,,,], [,,,,]],
-        ["/updateOrg/nodeTask1/**", [,,,,], [,,true,,]],
-        ["/updateOrg/nodeTask1", [,,,,], [,true,true,true,true]],
-        ["/updateOrg/nodeTask1/*", [,,,,], [,,true,,]],
-        ["/updateOrg/leafTask2", [,,,,], [,true,,true,true]],
-        ["/updateOrg/nodeTask", [,,,,], [,true,true,true,true]],
-        ["/updateOrg/leafTask", [,,,,], [,true,true,true,true]],
-        ["/updateOrg/*Task*", [,,,,], [,true,,true,true]],
-        ["/updateOrg/**/*+(2|12)", [,,,,], [,,,true,]],
-        ["/updateOrg/**/*+(1|2)", [,,,,], [,,,,]],
-        
-        ["/updateOrg/**/*+(2|12)", [,,,,true], [,true,,true,true]], //checking that the top task is also skipped when no child is executed
+        ["", [,,,,], [,,,,]],
+        ["*", [,,,,], [,true,true,true,true]],
+        ["*/*", [,,,,], [,true,,true,true]],
+        ["*/**", [,,,,], [,,,,]],
+        ["**", [,,,,], [,,,,]],
+        ["updateOrg/**", [,,,,], [,,,,]],
+        ["updateOrg/nodeTask1/**", [,,,,], [,,true,,]],
+        ["updateOrg/nodeTask1", [,,,,], [,true,true,true,true]],
+        ["updateOrg/nodeTask1/*", [,,,,], [,,true,,]],
+        ["updateOrg/leafTask2", [,,,,], [,true,,true,true]],
+        ["updateOrg/nodeTask", [,,,,], [,true,true,true,true]],
+        ["updateOrg/leafTask", [,,,,], [,true,true,true,true]],
+        ["updateOrg/*Task*", [,,,,], [,true,,true,true]],
+        ["updateOrg/**/*+(2|12)", [,,,,], [,,,true,]],
+        ["updateOrg/**/*+(1|2)", [,,,,], [,,,,]],
+        ["updateOrg/**/*+(2|12)", [,,,,true], [,true,,true,true]], //checking that the top task is also skipped when no child is executed
         
     ])("Task Matcher is present: %s", async (taskMatcher, skipTasks, skippedTasks) => {
         

--- a/test/unit-tests/commands/perform-tasks.test.ts
+++ b/test/unit-tests/commands/perform-tasks.test.ts
@@ -7,6 +7,7 @@ import { BuildTaskProvider } from '~build-tasks/build-task-provider';
 import { ConsoleUtil } from '~util/console-util';
 import { DeleteStacksCommand, BaseCliCommand } from '~commands/index';
 import { IUpdateOrganizationTaskConfiguration } from '~build-tasks/tasks/organization-task';
+import minimatch from "minimatch";
 
 describe('when creating perform-tasks command', () => {
     let command: PerformTasksCommand;
@@ -312,3 +313,178 @@ describe('when executing perform-tasks command', () => {
         });
     });
 });
+
+describe("when running perform-tasks with taskMatchers", () => {
+    
+    let commandArgs: IPerformTasksCommandArgs;
+    let taskConfig: IUpdateOrganizationTaskConfiguration[];
+    let performTaskState:PersistedState;
+    let buildRunnerRunTasksMock: jest.SpyInstance;
+    let commanderCommand:Command;
+    let command: PerformTasksCommand;
+    
+    
+    beforeEach(() => {
+        commandArgs = {
+            maxConcurrentStacks:1,
+            maxConcurrentTasks:1,
+            failedStacksTolerance:0,
+            failedTasksTolerance:0,
+            tasksFile: 'tasks.yml',
+            logicalName: 'default',
+        } as IPerformTasksCommandArgs
+        
+        taskConfig = [{
+            Type: 'update-organization',
+            LogicalName: 'updateOrg',
+            Template: 'organization.yml',
+        } as IUpdateOrganizationTaskConfiguration]
+        jest.spyOn(BuildConfiguration.prototype, 'enumBuildConfiguration').mockReturnValue(taskConfig);
+        
+        performTaskState = PersistedState.CreateEmpty('123123123123');
+        jest.spyOn(PerformTasksCommand.prototype, 'getState').mockReturnValue(Promise.resolve(performTaskState));
+        jest.spyOn(BuildConfiguration.prototype, 'fixateOrganizationFile').mockReturnValue(Promise.resolve(undefined));
+        
+        buildRunnerRunTasksMock = jest.spyOn(BuildRunner, 'RunTasks').mockImplementation();
+        
+        commanderCommand = new Command('root');
+        command = new PerformTasksCommand(commanderCommand);
+        
+    })
+    
+    afterEach(() => {
+        jest.restoreAllMocks();
+    })
+    
+    test("No taskMatchers",async () => {
+        const tasks = [{
+            name: 'updateOrg',
+            type: 'update-organization',
+            childTasks: [],
+            skip: undefined
+        }] as IBuildTask[];
+        jest.spyOn(BuildConfiguration.prototype, 'enumBuildTasks').mockReturnValue(tasks);
+        
+        await command.performCommand({ ...commandArgs, taskMatcher:undefined});
+        
+        const expectedTask = [{
+            name: 'updateOrg',
+            type: 'update-organization',
+            childTasks: [],
+            skip: undefined,
+        }] as IBuildTask[];
+        expect(buildRunnerRunTasksMock).toBeCalledWith(expectedTask, false, 1, 0);
+    })
+    
+    test.each([
+        ["match","*",true],
+        ["match","match",true],
+        ["/match","*",false],
+        ["/match","match",false],
+        ["/dontMatch/","*",false],
+        ["/folder/match","*",false],
+        ["/folder/dontMatch/","*",false],
+        
+        ["/match","/*",true],
+        ["/dontMatch/","/*",true],
+        ["/folder/dontMatch/","/*",false],
+        ["/folder/dontMatch","/*",false],
+        
+        ["/folder/match","/*/**",true],
+        ["/folder/","/*/**",true],
+        
+        ["/folder/","/*/**/*.(js|ts)",false],
+        ["/folder/some.js","/*/**/*+(.js|.ts)",true],
+        ["/folder/some.ts","/*/**/*+(.js|.ts)",true],
+        ["/folder/some.ts.d","/*/**/*+(.js|.ts)",false],
+        
+    ])("Testing Minimatch: %s, %s, %s", (str, globMatcher, result) => {
+        expect(minimatch(str,globMatcher)).toBe(result)
+        
+    })
+    
+    test.each([
+        //globMatcher, [updateOrg, node1, leaf2, leaf11, leaf12], [updateOrg, node1, leaf2, leaf11, leaf12]],
+        ["test", [,,,,], [,true,true,true,true]],
+        ["/", [,,,,], [,true,true,true,true]],
+        ["/*", [,,,,], [,true,true,true,true]],
+        ["/*/*", [,,,,], [,true,,true,true]],
+        ["/*/**", [,,,,], [,,,,]],
+        ["/**", [,,,,], [,,,,]],
+        ["/updateOrg/**", [,,,,], [,,,,]],
+        ["/updateOrg/nodeTask1/**", [,,,,], [,,true,,]],
+        ["/updateOrg/nodeTask1", [,,,,], [,true,true,true,true]],
+        ["/updateOrg/nodeTask1/*", [,,,,], [,,true,,]],
+        ["/updateOrg/leafTask2", [,,,,], [,true,,true,true]],
+        ["/updateOrg/nodeTask", [,,,,], [,true,true,true,true]],
+        ["/updateOrg/leafTask", [,,,,], [,true,true,true,true]],
+        ["/updateOrg/*Task*", [,,,,], [,true,,true,true]],
+        ["/updateOrg/**/*+(2|12)", [,,,,], [,,,true,]],
+        ["/updateOrg/**/*+(1|2)", [,,,,], [,,,,]],
+        
+        ["/updateOrg/**/*+(2|12)", [,,,,true], [,true,,true,true]], //checking that the top task is also skipped when no child is executed
+        
+    ])("Task Matchers are present: %s", async (taskMatcher, skipTasks, skippedTasks) => {
+        
+        const [updateOrgSkip, nodeTask1Skip, leafTask2Skip, leafTask11Skip, leafTask12Skip] = skipTasks
+        const tasks = [{
+            name: 'updateOrg',
+            type: 'update-organization',
+            skip: updateOrgSkip,
+            childTasks: [{
+                name: "nodeTask1",
+                type: "update-stacks",
+                skip: nodeTask1Skip,
+                childTasks: [{
+                    name: "leafTask11",
+                    type: "update-stacks",
+                    skip: leafTask11Skip,
+                    childTasks:[]
+                },{
+                    name: "leafTask12",
+                    type: "update-stacks",
+                    skip: leafTask12Skip,
+                    childTasks:[]
+                }]
+            },{
+                name: "leafTask2",
+                type: "update-stacks",
+                skip: leafTask2Skip,
+                childTasks: []
+            }]
+        }] as IBuildTask[];
+        jest.spyOn(BuildConfiguration.prototype, 'enumBuildTasks').mockReturnValue(tasks);
+        
+        await command.performCommand({ ...commandArgs, taskMatcher});
+        
+        const [skippedUpdateOrg, skippedNodeTask1, skippedLeafTask2, skippedLeafTask11, skippedLeafTask12] = skippedTasks
+        const expectedTask = [{
+            name: 'updateOrg',
+            type: 'update-organization',
+            skip: skippedUpdateOrg,
+            childTasks: [{
+                name: "nodeTask1",
+                type: "update-stacks",
+                skip: skippedNodeTask1,
+                childTasks:[{
+                    name: "leafTask11",
+                    type: "update-stacks",
+                    skip: skippedLeafTask11,
+                    childTasks:[]
+                },{
+                    name: "leafTask12",
+                    type: "update-stacks",
+                    skip: skippedLeafTask12,
+                    childTasks:[]
+                }]
+            },{
+                name: "leafTask2",
+                type: "update-stacks",
+                skip: skippedLeafTask2,
+                childTasks: []
+            }]
+        }] as IBuildTask[];
+        expect(buildRunnerRunTasksMock).toBeCalledWith(expectedTask, false, 1, 0);
+    })
+    
+})

--- a/test/unit-tests/commands/perform-tasks.test.ts
+++ b/test/unit-tests/commands/perform-tasks.test.ts
@@ -378,25 +378,27 @@ describe("when running perform-tasks with taskMatchers", () => {
 
     test.each([
         //globMatcher, [updateOrg, node1, leaf2, leaf11, leaf12], [updateOrg, node1, leaf2, leaf11, leaf12]],
-        ["test", [,,,,], [false,true,true,true,true]],
+        ["test", [,,,,], [true,true,true,true,true]],
         ["", [,,,,], [,,,,]], // "" is falsy, thus no matching.
-        ["*", [,,,,], [false,true,true,true,true]],
+        ["*", [,,,,], [true,true,true,true,true]],
         ["*/*", [,,,,], [false,true,false,true,true]],
         ["*/**", [,,,,], [false,false,false,false,false]],
         ["**", [,,,,], [false,false,false,false,false]],
         ["updateOrg/**", [,,,,], [false,false,false,false,false]],
         ["updateOrg/nodeTask1/**", [,,,,], [false,false,true,false,false]],
-        ["updateOrg/nodeTask1", [,,,,], [false,true,true,true,true]],
+        ["updateOrg/nodeTask1", [,,,,], [true,true,true,true,true]],
         ["updateOrg/nodeTask1/*", [,,,,], [false,false,true,false,false]],
         ["updateOrg/leafTask2", [,,,,], [false,true,false,true,true]],
-        ["updateOrg/nodeTask", [,,,,], [false,true,true,true,true]],
-        ["updateOrg/leafTask", [,,,,], [false,true,true,true,true]],
+        ["updateOrg/nodeTask", [,,,,], [true,true,true,true,true]],
+        ["updateOrg/leafTask", [,,,,], [true,true,true,true,true]],
         ["updateOrg/*Task*", [,,,,], [false,true,false,true,true]],
         ["updateOrg/**/*+(2|12)", [,,,,], [false,false,false,true,false]],
         ["updateOrg/**/*+(1|2)", [,,,,], [false,false,false,false,false]],
         ["updateOrg/**/*+(2|12)", [,,,,true], [false,false,false,true,false]], //checking unskip
         ["updateOrg/**/*Task2", [,,,,true], [false,true,false,true,true]], //checking that the top task is also skipped when no child is executed
         ["updateOrg/**/*11", [,true,,true,true], [false,false,true,false,true]], //parent is skipped but child matched, parent and child should be un-skipped.
+        ["**/3", [,,,,], [true,true,true,true,true]], //parent is skipped but child matched, parent and child should be un-skipped.
+        ["updateOrg/**", [,true,true,true,], [false,false,false,false,false]],
         
     ])("Task Matcher is present: %s", async (match, skipTasks, skippedTasks) => {
         

--- a/test/unit-tests/commands/perform-tasks.test.ts
+++ b/test/unit-tests/commands/perform-tasks.test.ts
@@ -365,7 +365,7 @@ describe("when running perform-tasks with taskMatchers", () => {
         }] as IBuildTask[];
         jest.spyOn(BuildConfiguration.prototype, 'enumBuildTasks').mockReturnValue(tasks);
         
-        await command.performCommand({ ...commandArgs, taskMatcher:undefined});
+        await command.performCommand({ ...commandArgs, match:undefined});
         
         const expectedTask = [{
             name: 'updateOrg',
@@ -398,7 +398,7 @@ describe("when running perform-tasks with taskMatchers", () => {
         ["updateOrg/**/*Task2", [,,,,true], [false,true,false,true,true]], //checking that the top task is also skipped when no child is executed
         ["updateOrg/**/*11", [,true,,true,true], [false,false,true,false,true]], //parent is skipped but child matched, parent and child should be un-skipped.
         
-    ])("Task Matcher is present: %s", async (taskMatcher, skipTasks, skippedTasks) => {
+    ])("Task Matcher is present: %s", async (match, skipTasks, skippedTasks) => {
         
         const [updateOrgSkip, nodeTask1Skip, leafTask2Skip, leafTask11Skip, leafTask12Skip] = skipTasks
         const tasks = [{
@@ -429,7 +429,7 @@ describe("when running perform-tasks with taskMatchers", () => {
         }] as IBuildTask[];
         jest.spyOn(BuildConfiguration.prototype, 'enumBuildTasks').mockReturnValue(tasks);
         
-        await command.performCommand({ ...commandArgs, taskMatcher});
+        await command.performCommand({ ...commandArgs, match});
         
         const [skippedUpdateOrg, skippedNodeTask1, skippedLeafTask2, skippedLeafTask11, skippedLeafTask12] = skippedTasks
         const expectedTask = [{

--- a/test/unit-tests/commands/perform-tasks.test.ts
+++ b/test/unit-tests/commands/perform-tasks.test.ts
@@ -378,23 +378,25 @@ describe("when running perform-tasks with taskMatchers", () => {
 
     test.each([
         //globMatcher, [updateOrg, node1, leaf2, leaf11, leaf12], [updateOrg, node1, leaf2, leaf11, leaf12]],
-        ["test", [,,,,], [,true,true,true,true]],
-        ["", [,,,,], [,,,,]],
-        ["*", [,,,,], [,true,true,true,true]],
-        ["*/*", [,,,,], [,true,,true,true]],
-        ["*/**", [,,,,], [,,,,]],
-        ["**", [,,,,], [,,,,]],
-        ["updateOrg/**", [,,,,], [,,,,]],
-        ["updateOrg/nodeTask1/**", [,,,,], [,,true,,]],
-        ["updateOrg/nodeTask1", [,,,,], [,true,true,true,true]],
-        ["updateOrg/nodeTask1/*", [,,,,], [,,true,,]],
-        ["updateOrg/leafTask2", [,,,,], [,true,,true,true]],
-        ["updateOrg/nodeTask", [,,,,], [,true,true,true,true]],
-        ["updateOrg/leafTask", [,,,,], [,true,true,true,true]],
-        ["updateOrg/*Task*", [,,,,], [,true,,true,true]],
-        ["updateOrg/**/*+(2|12)", [,,,,], [,,,true,]],
-        ["updateOrg/**/*+(1|2)", [,,,,], [,,,,]],
-        ["updateOrg/**/*+(2|12)", [,,,,true], [,true,,true,true]], //checking that the top task is also skipped when no child is executed
+        ["test", [,,,,], [false,true,true,true,true]],
+        ["", [,,,,], [,,,,]], // "" is falsy, thus no matching.
+        ["*", [,,,,], [false,true,true,true,true]],
+        ["*/*", [,,,,], [false,true,false,true,true]],
+        ["*/**", [,,,,], [false,false,false,false,false]],
+        ["**", [,,,,], [false,false,false,false,false]],
+        ["updateOrg/**", [,,,,], [false,false,false,false,false]],
+        ["updateOrg/nodeTask1/**", [,,,,], [false,false,true,false,false]],
+        ["updateOrg/nodeTask1", [,,,,], [false,true,true,true,true]],
+        ["updateOrg/nodeTask1/*", [,,,,], [false,false,true,false,false]],
+        ["updateOrg/leafTask2", [,,,,], [false,true,false,true,true]],
+        ["updateOrg/nodeTask", [,,,,], [false,true,true,true,true]],
+        ["updateOrg/leafTask", [,,,,], [false,true,true,true,true]],
+        ["updateOrg/*Task*", [,,,,], [false,true,false,true,true]],
+        ["updateOrg/**/*+(2|12)", [,,,,], [false,false,false,true,false]],
+        ["updateOrg/**/*+(1|2)", [,,,,], [false,false,false,false,false]],
+        ["updateOrg/**/*+(2|12)", [,,,,true], [false,false,false,true,false]], //checking unskip
+        ["updateOrg/**/*Task2", [,,,,true], [false,true,false,true,true]], //checking that the top task is also skipped when no child is executed
+        ["updateOrg/**/*11", [,true,,true,true], [false,false,true,false,true]], //parent is skipped but child matched, parent and child should be un-skipped.
         
     ])("Task Matcher is present: %s", async (taskMatcher, skipTasks, skippedTasks) => {
         


### PR DESCRIPTION
When executing the `perform-tasks` command it is possible to use the optional flag `--task-matcher` to specify a glob pattern. The glob pattern is used to filter and skip all of the non-matching tasks.

It works by composing a `fullTaskName` based on the `task.name` and its `parentTask.name`. The obtained `fullTaskName` is then matched against the provided glob pattern to decide if the task should be skipped or not (this is done only for the leaf tasks). Any non-matching `fullTaskName` will be skipped from execution.
* If a `parentTask` has all of its `childTasks` skipped then the `parentTask` is also skipped
* this flag gives priority to the `skip` property of a task. If a task has the `skip` property set to `true` then even if the task matches the glob pattern it will still be skipped.

Note: when running the `perform-tasks` with the `--task-matcher` command make sure to have the glob pattern in quotes otherwise you may end up listing your root or current directory

Examples: 
* `org-formation perform-tasks ./src/_tasks-tst.yml --task-matcher '/Test/SomeServiceLogicalName'`
* `org-formation perform-tasks ./src/_tasks-tst.yml --task-matcher '/*/**/SomeServiceLogicalName'`,
* `org-formation perform-tasks ./src/_tasks-tst.yml --task-matcher '/*/**/*+(Service|Lambda)'`,