### PR TITLE
feat: support for parameters in sls v3

### DIFF
--- a/src/plugin/impl/sls-build-task-plugin.ts
+++ b/src/plugin/impl/sls-build-task-plugin.ts
@@ -190,7 +190,7 @@ export class SlsBuildTaskPlugin implements IBuildTaskPlugin<IServerlessComTaskCo
     static GetParametersAsArgument(parameters: Record<string, any>): string {
         if (!parameters) {return '';}
         const entries = Object.entries(parameters);
-        return entries.reduce((prev, curr) => prev + `--${curr[0]} "${curr[1]}" `, '');
+        return entries.reduce((prev, curr) => prev + `--param="${curr[0]}=${curr[1]}" `, '');
     }
 }
 

--- a/test/unit-tests/plugin/impl/sls-build-task-plugin.test.ts
+++ b/test/unit-tests/plugin/impl/sls-build-task-plugin.test.ts
@@ -128,7 +128,7 @@ describe('when resolving attribute expressions on update', () => {
         await binder.createPerformForUpdateOrCreate(binding)();
 
         expect(spawnProcessForAccountSpy).toHaveBeenCalledTimes(1);
-        expect(spawnProcessForAccountSpy).lastCalledWith(expect.anything(), expect.stringContaining('--param "val"'), expect.anything(), undefined, expect.anything(), true);
+        expect(spawnProcessForAccountSpy).lastCalledWith(expect.anything(), expect.stringContaining('--param="param=val"'), expect.anything(), undefined, expect.anything(), true);
     });
 
 
@@ -141,7 +141,7 @@ describe('when resolving attribute expressions on update', () => {
         await binder.createPerformForUpdateOrCreate(binding)();
 
         expect(spawnProcessForAccountSpy).toHaveBeenCalledTimes(1);
-        expect(spawnProcessForAccountSpy).lastCalledWith(expect.anything(), expect.stringContaining('--param "val"'), expect.anything(), undefined, expect.anything(), true);
+        expect(spawnProcessForAccountSpy).lastCalledWith(expect.anything(), expect.stringContaining('--param="param=val"'), expect.anything(), undefined, expect.anything(), true);
         expect(spawnProcessForAccountSpy).lastCalledWith(expect.anything(), expect.stringContaining(' 1232342341235 '), expect.anything(), undefined, expect.anything(), true);
     });
 
@@ -204,7 +204,7 @@ describe('when resolving attribute expressions on update', () => {
         await binder.createPerformForUpdateOrCreate(binding)();
 
         expect(spawnProcessForAccountSpy).toHaveBeenCalledTimes(1);
-        expect(spawnProcessForAccountSpy).lastCalledWith(expect.anything(), expect.stringContaining('--myAccountList "1232342341234|1232342341235"'), expect.anything(), undefined, expect.anything(), true);
+        expect(spawnProcessForAccountSpy).lastCalledWith(expect.anything(), expect.stringContaining('--param="myAccountList=1232342341234|1232342341235"'), expect.anything(), undefined, expect.anything(), true);
     });
 
     test('unresolvable expression will throw exception', async () => {
@@ -312,7 +312,7 @@ describe('when resolving attribute expressions on remove', () => {
         await binder.createPerformForRemove(binding)();
 
         expect(spawnProcessForAccountSpy).toHaveBeenCalledTimes(1);
-        expect(spawnProcessForAccountSpy).lastCalledWith(expect.anything(), expect.stringContaining('--param "val"'), expect.anything(), undefined, expect.anything(), true);
+        expect(spawnProcessForAccountSpy).lastCalledWith(expect.anything(), expect.stringContaining('--param="param=val"'), expect.anything(), undefined, expect.anything(), true);
     });
 
     test('custom deploy command can use multiple substitutions', async () => {
@@ -324,7 +324,7 @@ describe('when resolving attribute expressions on remove', () => {
         await binder.createPerformForRemove(binding)();
 
         expect(spawnProcessForAccountSpy).toHaveBeenCalledTimes(1);
-        expect(spawnProcessForAccountSpy).lastCalledWith(expect.anything(), expect.stringContaining('--param "val"'), expect.anything(), undefined, expect.anything(), true);
+        expect(spawnProcessForAccountSpy).lastCalledWith(expect.anything(), expect.stringContaining('--param="param=val"'), expect.anything(), undefined, expect.anything(), true);
         expect(spawnProcessForAccountSpy).lastCalledWith(expect.anything(), expect.stringContaining(' 1232342341235 '), expect.anything(), undefined, expect.anything(), true);
     });
 
@@ -405,7 +405,7 @@ describe('when resolving attribute expressions on remove', () => {
         await binder.createPerformForRemove(binding)();
 
         expect(spawnProcessForAccountSpy).toHaveBeenCalledTimes(1);
-        expect(spawnProcessForAccountSpy).lastCalledWith(expect.anything(), expect.stringContaining('--myAccountList "1232342341234|1232342341235"'), expect.anything(), undefined, expect.anything(), true);
+        expect(spawnProcessForAccountSpy).lastCalledWith(expect.anything(), expect.stringContaining('--param="myAccountList=1232342341234|1232342341235"'), expect.anything(), undefined, expect.anything(), true);
     });
 
 


### PR DESCRIPTION
This PR aims to fix #303 

At the moment, parameters in update-serverless task are being rendered as `--paramName="paramValue"` but since serverless v3 this has changed to `--param="paramName=paramValue` 

