### PR TITLE
fix: adds missing language extensions yaml tags

### DIFF
--- a/src/yaml-cfn/index.ts
+++ b/src/yaml-cfn/index.ts
@@ -112,6 +112,8 @@ const supportedFunctions = [
   'Fn::MD5File',
   'Fn::JsonString',
   'Fn::Include',
+  'Fn::ToJsonString',
+  'Fn::Length',
 ];
 
 const allTagTypes = [];
@@ -166,4 +168,3 @@ export const NunjucksDebugSettings = {
   debug: false,
   path: './.nunjucks-debug/',
 };
-


### PR DESCRIPTION
Adds the new tags that can be found in the `AWS::LanguageExtensions` transform:

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-languageextension-transform.html