### PR TITLE
update to codebuild standard 6

### DIFF
--- a/resources/orgformation-codepipeline.yml
+++ b/resources/orgformation-codepipeline.yml
@@ -317,7 +317,7 @@ Resources:
       Artifacts: { Type: NO_ARTIFACTS }
       Environment:
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/standard:4.0
+        Image: aws/codebuild/standard:6.0
         ComputeType: BUILD_GENERAL1_SMALL
         ImagePullCredentialsType: CODEBUILD
       QueuedTimeoutInMinutes: 480


### PR DESCRIPTION
AWS has announced the deprecation of codebuild standard image version 4. This sets the version to 6 for new users of org-formation pipeline. 

Deprecation will start march 31, 2023. If you're using a version 4 image, you should have gotten an email from AWS.

I've tested this by updating the image to v6 in an existing deployment.

AWS's message:

```
Hello,

We are reaching out to you because you ran a build using the Ubuntu standard 4.0 [1] Docker Image, in the last 30 days.

Starting March 30, 2023, AWS CodeBuild will be moving these images to an unsupported status and they will not be cached on the build hosts anymore.

You may continue using these images for your builds, but will notice an increase in provisioning latency after March 30, 2023.

These images will also not be getting any new updates. We recommend updating your Build Projects to use the latest build images in order to get the latest language runtimes and tools. For more information on how to do this you can follow 'Docker images provided by CodeBuild' [2].

If you have any questions or concerns, please reach out to AWS Support [3].

[1] Platform: Ubuntu 18.04 - Image: aws/codebuild/standard:4.0 - Definition: ubuntu/standard/4.0

[2] https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html

[3] https://aws.amazon.com/support

Sincerely,
Amazon Web Services
```