### PR TITLE
fix: add region to cdk resolver and update default cdk deploy command

### DIFF
--- a/src/plugin/impl/cdk-build-task-plugin.ts
+++ b/src/plugin/impl/cdk-build-task-plugin.ts
@@ -124,7 +124,7 @@ export class CdkBuildTaskPlugin implements IBuildTaskPlugin<ICdkBuildTaskConfig,
             Validator.throwForUnresolvedExpressions(task.customDeployCommand, 'CustomDeployCommand');
             command = task.customDeployCommand as string;
         } else {
-            const commandExpression = { 'Fn::Sub': 'npx cdk deploy --all --require-approval=never ${CurrentTask.Parameters}' } as ICfnSubExpression;
+            const commandExpression = { 'Fn::Sub': 'npx cdk deploy --all --require-approval=never ${CurrentTask.Parameters} --output cdk.out/${CurrentTask.AccountId}-${CurrentTask.Region}' } as ICfnSubExpression;
             command = await resolver.resolveSingleExpression(commandExpression, 'CustomDeployCommand');
 
             if (task.runNpmBuild) {
@@ -181,7 +181,7 @@ export class CdkBuildTaskPlugin implements IBuildTaskPlugin<ICdkBuildTaskConfig,
         const p = await resolver.resolve(task.parameters);
         const collapsed = await resolver.collapse(p);
         const parametersAsString = CdkBuildTaskPlugin.GetParametersAsArgument(collapsed);
-        resolver.addResourceWithAttributes('CurrentTask',  { Parameters : parametersAsString, AccountId : binding.target.accountId });
+        resolver.addResourceWithAttributes('CurrentTask',  { Parameters : parametersAsString, AccountId : binding.target.accountId, Region: binding.target.region });
     }
 
     static GetEnvironmentVariables(target: IGenericTarget<ICdkTask>): Record<string, string> {


### PR DESCRIPTION
If a certain cdk task has concurrency enabled and is deployed to multiple regions the cdk.out error will appear.

For this I added the Region value to the CurrentTask object and also updated the default CDK Deploy command 