### PR TITLE
Format SCP without indentation reducing policy size

### DIFF
--- a/src/aws-provider/aws-organization-writer.ts
+++ b/src/aws-provider/aws-organization-writer.ts
@@ -60,7 +60,7 @@ export class AwsOrganizationWriter {
                     Name: resource.policyName,
                     Description: resource.description!,
                     Type: 'SERVICE_CONTROL_POLICY',
-                    Content: JSON.stringify(resource.policyDocument, null, 2),
+                    Content: JSON.stringify(resource.policyDocument, null, 0),
                 });
                 const response = await this.organizationsService.send(createPolicyCommand);
                 const scpId = response.Policy!.PolicySummary!.Id!;
@@ -130,7 +130,7 @@ export class AwsOrganizationWriter {
                 PolicyId: physicalId,
                 Name: resource.policyName,
                 Description: resource.description,
-                Content: JSON.stringify(resource.policyDocument, null, 2),
+                Content: JSON.stringify(resource.policyDocument, null, 0),
             });
             await this.organizationsService.send(updatePolicyCommand);
         });


### PR DESCRIPTION
This will allow for the maximum characters 5120 to be used without whitespace counting towards that total. AWS will store the policy in the minified state but render it in the console with pretty print.