### PR TITLE
fix: access denied error when using build-account-id for init-pipeline

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -295,6 +295,18 @@ export abstract class BaseCliCommand<T extends ICommandArgs> {
     protected async initialize(command: ICommandArgs): Promise<void> {
         if (command.initialized) { return; }
 
+        if (command.printStack === true) {
+            ConsoleUtil.printStacktraces = true;
+            Error.stackTraceLimit = 50;
+        }
+        if (command.verbose === true) {
+            ConsoleUtil.verbose = true;
+        }
+
+        if (command.color === false) {
+            ConsoleUtil.colorizeLogs = false;
+        }
+
         // create a copy of `command` to ensure no circular references
         ConsoleUtil.LogDebug(`initializing, arguments: \n${JSON.stringify({
             stateBucketName: command.stateBucketName,
@@ -311,17 +323,6 @@ export abstract class BaseCliCommand<T extends ICommandArgs> {
             const exclude = !command.excludeAccounts ? [] : command.excludeAccounts.split(',').map(x => x.trim());
             ConsoleUtil.LogInfo(`excluding the following accounts: ${exclude.join(', ')}`);
             AwsOrganizationReader.excludeAccountIds = exclude;
-        }
-
-        if (command.printStack === true) {
-            ConsoleUtil.printStacktraces = true;
-            Error.stackTraceLimit = 50;
-        }
-        if (command.verbose === true) {
-            ConsoleUtil.verbose = true;
-        }
-        if (command.color === false) {
-            ConsoleUtil.colorizeLogs = false;
         }
 
         if (command.masterAccountId !== undefined) {

--- a/src/commands/init-organization-pipeline.ts
+++ b/src/commands/init-organization-pipeline.ts
@@ -53,6 +53,7 @@ export class InitPipelineCommand extends BaseCliCommand<IInitPipelineCommandArgs
             command.buildProcessRoleName = 'OrganizationFormationBuildAccessRole';
             this.buildAccountId = command.buildAccountId;
             this.s3credentials = await AwsUtil.GetCredentials(command.buildAccountId, DEFAULT_ROLE_FOR_CROSS_ACCOUNT_ACCESS.RoleName, AwsUtil.GetDefaultRegion());
+            AwsUtil.SetBuildProcessAccountId(command.buildAccountId);
         }
         if (command.crossAccountRoleName) {
             DEFAULT_ROLE_FOR_CROSS_ACCOUNT_ACCESS.RoleName = command.crossAccountRoleName;

--- a/src/state/storage-provider.ts
+++ b/src/state/storage-provider.ts
@@ -56,7 +56,8 @@ export class S3StorageProvider implements IStorageProvider {
             };
         }
 
-        const s3client = AwsUtil.GetS3Service(undefined, region);
+        const buildAccountId = await AwsUtil.GetBuildProcessAccountId();
+        const s3client = AwsUtil.GetS3Service(buildAccountId, region);
         try {
             await s3client.send(new S3.CreateBucketCommand(request));
             await s3client.send(new S3.PutPublicAccessBlockCommand({
@@ -131,7 +132,8 @@ export class S3StorageProvider implements IStorageProvider {
         }
 
         try {
-            const s3client = AwsUtil.GetS3Service(undefined, this.region);
+            const buildAccountId = await AwsUtil.GetBuildProcessAccountId();
+            const s3client = AwsUtil.GetS3Service(buildAccountId, this.region);
 
             const putObjectRequest: S3.PutObjectCommandInput = {
                 Bucket: this.bucketName,

--- a/src/util/aws-util.ts
+++ b/src/util/aws-util.ts
@@ -146,6 +146,10 @@ export class AwsUtil {
         AwsUtil.masterAccountId = masterAccountId;
     }
 
+    public static SetBuildProcessAccountId(buildAccountId: string): void {
+        AwsUtil.buildProcessAccountId = buildAccountId;
+    }
+
     public static SetProfile(profile: string): void {
         AwsUtil.profile = profile;
     }


### PR DESCRIPTION
Resolves issue where state bucket was being created in management account when using build account.  This appeared to be a regression from the v3 AWS cli update change.

Fixes: #548 